### PR TITLE
Fixing squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/CollectionRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/CollectionRefactoring.java
@@ -130,7 +130,7 @@ public class CollectionRefactoring extends AbstractRefactoringRule {
             return false;
         }
         final List<Expression> args = arguments(cic);
-        final boolean noArgsCtor = args.size() == 0;
+        final boolean noArgsCtor = args.isEmpty();
         final boolean colCapacityCtor = args.size() == 1 && isPrimitive(args.get(0), "int");
         if (noArgsCtor && hasType(cic,
                 "java.util.concurrent.ConcurrentLinkedDeque",

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
@@ -264,7 +264,7 @@ public class CommonCodeInIfElseStatementRefactoring extends AbstractRefactoringR
     }
 
     private int minSize(List<List<Statement>> allCasesStmts) {
-    	if (allCasesStmts.isEmpty()) {
+        if (allCasesStmts.isEmpty()) {
             throw new IllegalStateException(null, "allCasesStmts List must not be empty");
         }
         int min = Integer.MAX_VALUE;

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
@@ -264,7 +264,7 @@ public class CommonCodeInIfElseStatementRefactoring extends AbstractRefactoringR
     }
 
     private int minSize(List<List<Statement>> allCasesStmts) {
-        if (allCasesStmts.size() == 0) {
+    	if (allCasesStmts.isEmpty()) {
             throw new IllegalStateException(null, "allCasesStmts List must not be empty");
         }
         int min = Integer.MAX_VALUE;

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/MapRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/MapRefactoring.java
@@ -111,7 +111,7 @@ public class MapRefactoring extends AbstractRefactoringRule {
             return false;
         }
         final List<Expression> args = arguments(cic);
-        final boolean noArgsCtor = args.size() == 0;
+        final boolean noArgsCtor = args.isEmpty();
         final boolean mapCapacityCtor = args.size() == 1 && isPrimitive(args.get(0), "int");
         if (noArgsCtor && hasType(cic,
                 "java.util.concurrent.ConcurrentHashMap",

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/ReduceVariableScopeRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/ReduceVariableScopeRefactoring.java
@@ -212,8 +212,7 @@ public class ReduceVariableScopeRefactoring extends AbstractRefactoringRule {
                 list = new ArrayList<VariableAccess>();
                 this.allVariableAccesses.put(varName, list);
             }
-            if (list.size() == 0
-                    || !list.get(list.size() - 1).getScope().equals(accessTypeAndScope.getSecond())) {
+            if (list.isEmpty() || !list.get(list.size() - 1).getScope().equals(accessTypeAndScope.getSecond())) {
                 // only keep first write in scope
                 list.add(new VariableAccess(node, accessTypeAndScope.getFirst(), accessTypeAndScope.getSecond()));
             }

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/StringBuilderRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/StringBuilderRefactoring.java
@@ -284,7 +284,7 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
 
     private Expression createStringConcats(List<Expression> appendedStrings) {
         final ASTBuilder b = this.ctx.getASTBuilder();
-        if (appendedStrings.size() == 0) {
+        if (appendedStrings.isEmpty()) {
             return b.string("");
         } else if (appendedStrings.size() == 1) {
             final Expression expr = appendedStrings.get(0);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 -  Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Sameer Misger
