### PR TITLE
Enable default rule configuration. Closes #29

### DIFF
--- a/plugin/src/main/java/org/autorefactor/preferences/PreferenceConstants.java
+++ b/plugin/src/main/java/org/autorefactor/preferences/PreferenceConstants.java
@@ -33,20 +33,8 @@ public enum PreferenceConstants {
     /** Preference that turns debug mode on or off. */
     DEBUG_MODE_ON(
             "debug_mode_on",
-            "Enable debug mode (for developers only)",
-            Boolean.FALSE),
-
-    /** Preference that configures whether to add curly brackets to statement bodies. */
-    ADD_CURLY_BRACKETS_TO_STATEMENT_BODIES(
-            "add_curly_brackets_to_statement_bodies",
-            "Add curly brackets '{' and '}' to statement bodies",
-            Boolean.TRUE),
-
-    /** Preference that configures whether to remove <code>this</code> for non static method accesses. */
-    REMOVE_THIS_FOR_NON_STATIC_METHOD_ACCESS(
-            "remove_this_for_non_static_method_access",
-            "Remove 'this' qualifier for non static method accesses",
-            Boolean.TRUE);
+            "Enable debug mode (for developers)",
+            Boolean.FALSE);
 
     /** TODO use this for preferences initialization. */
     private static final String JDT_ALWAYS_USE_THIS_FOR_NON_STATIC_METHOD_ACCESS =

--- a/plugin/src/main/java/org/autorefactor/preferences/Preferences.java
+++ b/plugin/src/main/java/org/autorefactor/preferences/Preferences.java
@@ -25,6 +25,8 @@
  */
 package org.autorefactor.preferences;
 
+import org.autorefactor.refactoring.rules.AbstractRefactoringRule;
+
 /**
  * Helper interface for preferences.
  */
@@ -38,17 +40,11 @@ public interface Preferences {
     boolean debugModeOn();
 
     /**
-     * Returns whether to remove 'this' keyword for accesses to non static methods.
+     * Returns whether this refactoring rule is on.
      *
-     * @return true if must remove 'this' keyword for accesses to non static methods, false otherwise
+     * @param clazz The class.
+     * @return true if this refactoring rule is on, false otherwise.
      */
-    boolean removeThisForNonStaticMethodAccess();
-
-    /**
-     * Returns whether debug mode is on.
-     *
-     * @return true if debug mode is on, false otherwise.
-     */
-    boolean addCurlyBracketsToStatementBodies();
+    boolean isEnabled(Class<? extends AbstractRefactoringRule> clazz);
 
 }

--- a/plugin/src/main/java/org/autorefactor/refactoring/RefactoringRule.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/RefactoringRule.java
@@ -60,6 +60,13 @@ public interface RefactoringRule {
     Refactorings getRefactorings(CompilationUnit astRoot);
 
     /**
+     * True if the refactoring is pre-configured.
+     *
+     * @return True if the refactoring is pre-configured.
+     */
+    boolean isByDefault();
+
+    /**
      * Returns whether the current refactoring is enabled by the preferences.
      *
      * @param preferences the preferences

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/AbstractRefactoringRule.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/AbstractRefactoringRule.java
@@ -41,8 +41,13 @@ public abstract class AbstractRefactoringRule extends ASTVisitor implements Java
     protected RefactoringContext ctx;
 
     @Override
-    public boolean isEnabled(Preferences preferences) {
+    public boolean isByDefault() {
         return true;
+    }
+
+    @Override
+    public boolean isEnabled(Preferences preferences) {
+        return preferences.isEnabled(this.getClass());
     }
 
     @Override

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/AddBracketsToControlStatementRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/AddBracketsToControlStatementRefactoring.java
@@ -25,7 +25,6 @@
  */
 package org.autorefactor.refactoring.rules;
 
-import org.autorefactor.preferences.Preferences;
 import org.autorefactor.refactoring.ASTBuilder;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.DoStatement;
@@ -53,11 +52,6 @@ public class AddBracketsToControlStatementRefactoring extends AbstractRefactorin
     @Override
     public String getName() {
         return "Add brackets to control statement";
-    }
-
-    @Override
-    public boolean isEnabled(final Preferences prefs) {
-        return prefs.addCurlyBracketsToStatementBodies();
     }
 
     @Override

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/AggregateASTVisitor.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/AggregateASTVisitor.java
@@ -3029,4 +3029,9 @@ public class AggregateASTVisitor extends ASTVisitor implements JavaRefactoringRu
         }
         return VISIT_SUBTREE;
     }
+
+    @Override
+    public boolean isByDefault() {
+        return false;
+    }
 }

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/RemoveUnneededThisExpressionRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/RemoveUnneededThisExpressionRefactoring.java
@@ -25,7 +25,6 @@
  */
 package org.autorefactor.refactoring.rules;
 
-import org.autorefactor.preferences.Preferences;
 import org.autorefactor.util.NotImplementedException;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
@@ -52,11 +51,6 @@ public class RemoveUnneededThisExpressionRefactoring extends AbstractRefactoring
     @Override
     public String getName() {
         return "Remove unneeded this expressions";
-    }
-
-    @Override
-    public boolean isEnabled(Preferences preferences) {
-        return preferences.removeThisForNonStaticMethodAccess();
     }
 
     @Override

--- a/plugin/src/main/java/org/autorefactor/ui/preferences/EclipsePreferences.java
+++ b/plugin/src/main/java/org/autorefactor/ui/preferences/EclipsePreferences.java
@@ -27,6 +27,7 @@ package org.autorefactor.ui.preferences;
 
 import org.autorefactor.preferences.PreferenceConstants;
 import org.autorefactor.preferences.Preferences;
+import org.autorefactor.refactoring.rules.AbstractRefactoringRule;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import static org.autorefactor.preferences.PreferenceConstants.*;
@@ -54,12 +55,7 @@ public class EclipsePreferences implements Preferences {
     }
 
     @Override
-    public boolean removeThisForNonStaticMethodAccess() {
-        return getBoolean(REMOVE_THIS_FOR_NON_STATIC_METHOD_ACCESS);
-    }
-
-    @Override
-    public boolean addCurlyBracketsToStatementBodies() {
-        return getBoolean(ADD_CURLY_BRACKETS_TO_STATEMENT_BODIES);
+    public boolean isEnabled(Class<? extends AbstractRefactoringRule> clazz) {
+        return preferenceStore.getBoolean(clazz.getCanonicalName());
     }
 }

--- a/plugin/src/main/java/org/autorefactor/ui/preferences/PreferenceInitializer.java
+++ b/plugin/src/main/java/org/autorefactor/ui/preferences/PreferenceInitializer.java
@@ -27,11 +27,11 @@ package org.autorefactor.ui.preferences;
 
 import org.autorefactor.AutoRefactorPlugin;
 import org.autorefactor.preferences.PreferenceConstants;
+import org.autorefactor.refactoring.RefactoringRule;
+import org.autorefactor.refactoring.rules.AllRefactoringRules;
 import org.autorefactor.util.NotImplementedException;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
-
-import static org.autorefactor.preferences.PreferenceConstants.*;
 
 /**
  * Initializes the Eclipse preferences for AutoRefactor.
@@ -63,7 +63,10 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
                 throw new NotImplementedException(null, defaultValue);
             }
         }
-        store.setDefault(ADD_CURLY_BRACKETS_TO_STATEMENT_BODIES.getName(), true);
+
+        for (RefactoringRule refactoringRule : AllRefactoringRules.getAllRefactoringRules()) {
+            store.setDefault(refactoringRule.getClass().getCanonicalName(), refactoringRule.isByDefault());
+        }
     }
 
 }

--- a/plugin/src/main/java/org/autorefactor/ui/preferences/WorkspacePreferencePage.java
+++ b/plugin/src/main/java/org/autorefactor/ui/preferences/WorkspacePreferencePage.java
@@ -26,43 +26,200 @@
 package org.autorefactor.ui.preferences;
 
 import org.autorefactor.AutoRefactorPlugin;
-import org.autorefactor.preferences.PreferenceConstants;
+import org.autorefactor.refactoring.RefactoringRule;
+import org.autorefactor.refactoring.rules.AllRefactoringRules;
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.FieldEditor;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import static org.autorefactor.preferences.PreferenceConstants.*;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 
 /**
  * The Eclipse preference page for AutoRefactor.
  */
-public class WorkspacePreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class WorkspacePreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
+
+    private Button toggleAllRules;
+
+    private List<BooleanFieldEditor> rules;
+
+    private List<FieldEditor> fields;
+
+    private FieldEditor invalidFieldEditor;
+
+    private Composite fieldEditorParent;
 
     /** Default constructor. */
     public WorkspacePreferencePage() {
-        super(GRID);
+        super("AutoRefactor workbench preferences");
         setPreferenceStore(AutoRefactorPlugin.getDefault().getPreferenceStore());
-        setDescription("AutoRefactor workbench preferences");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    protected void createFieldEditors() {
-        addBooleanField(REMOVE_THIS_FOR_NON_STATIC_METHOD_ACCESS);
-        addBooleanField(ADD_CURLY_BRACKETS_TO_STATEMENT_BODIES);
-
-        addBooleanField(DEBUG_MODE_ON);
-    }
-
-    private void addBooleanField(PreferenceConstants pref) {
-        addField(new BooleanFieldEditor(pref.getName(), pref.getDescription(), getFieldEditorParent()));
     }
 
     /** {@inheritDoc} */
     @Override
     public void init(IWorkbench workbench) {
+    }
+
+    @Override
+    protected Control createContents(Composite parent) {
+        final List<RefactoringRule> allRefactoringRules = AllRefactoringRules.getAllRefactoringRules();
+        Collections.sort(allRefactoringRules, new Comparator<RefactoringRule>() {
+            @Override
+            public int compare(final RefactoringRule o1, final RefactoringRule o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+
+        });
+
+        final Group ruleGroup = createControls(parent, allRefactoringRules);
+
+        initialize();
+        invalidateToggleRules(ruleGroup);
+
+        checkState();
+        return fieldEditorParent;
+    }
+
+    private Group createControls(final Composite parent, final List<RefactoringRule> allRefactoringRules) {
+        fieldEditorParent = new Composite(parent, SWT.FILL);
+
+        fields = new ArrayList<FieldEditor>(1 + allRefactoringRules.size());
+
+        fields.add(new BooleanFieldEditor(DEBUG_MODE_ON.getName(), DEBUG_MODE_ON.getDescription(),
+                fieldEditorParent));
+
+        final Group ruleGroup = new Group(fieldEditorParent, SWT.FILL);
+        ruleGroup.setText("Rules by default");
+
+        // All rule checkbox
+        toggleAllRules = new Button(ruleGroup, SWT.CHECK | SWT.LEFT);
+        toggleAllRules.setFont(ruleGroup.getFont());
+        toggleAllRules.setText("Toggle all the rules");
+        toggleAllRules.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent e) {
+                boolean isSelected = WorkspacePreferencePage.this.toggleAllRules.getSelection();
+                for (BooleanFieldEditor rule : WorkspacePreferencePage.this.rules) {
+                    ((Button) rule.getDescriptionControl(ruleGroup)).setSelection(isSelected);
+                }
+            }
+        });
+
+        // Add a space
+        new Label(ruleGroup, SWT.NULL);
+
+        rules = new ArrayList<BooleanFieldEditor>(allRefactoringRules.size());
+        for (final RefactoringRule refactoringRule : allRefactoringRules) {
+            final BooleanFieldEditor booleanFieldEditor = new BooleanFieldEditor(
+                    refactoringRule.getClass().getCanonicalName(),
+                    refactoringRule.getName(), SWT.WRAP, ruleGroup);
+            booleanFieldEditor.getDescriptionControl(ruleGroup).setToolTipText(refactoringRule.getDescription());
+            ((Button) booleanFieldEditor.getDescriptionControl(ruleGroup)).addSelectionListener(new SelectionAdapter() {
+                public void widgetSelected(final SelectionEvent e) {
+                    invalidateToggleRules(ruleGroup);
+                }
+            });
+            rules.add(booleanFieldEditor);
+        }
+        fields.addAll(rules);
+        return ruleGroup;
+    }
+
+    private void invalidateToggleRules(final Composite ruleGroup) {
+        boolean isAllRulesChecked = true;
+        for (final BooleanFieldEditor rule : WorkspacePreferencePage.this.rules) {
+            isAllRulesChecked = ((Button) rule.getDescriptionControl(ruleGroup)).getSelection();
+            if (!isAllRulesChecked) {
+                break;
+            }
+        }
+        toggleAllRules.setSelection(isAllRulesChecked);
+    }
+
+    /**
+     * Initialize.
+     */
+    protected void initialize() {
+        if (fields != null) {
+            for (final FieldEditor field : fields) {
+                field.setPage(this);
+                field.setPreferenceStore(getPreferenceStore());
+                field.load();
+            }
+        }
+    }
+
+    /**
+     * Check the state.
+     */
+    protected void checkState() {
+        boolean valid = true;
+        invalidFieldEditor = null;
+
+        if (fields != null) {
+            for (final FieldEditor field : fields) {
+                valid = field.isValid();
+                if (!valid) {
+                    invalidFieldEditor = field;
+                    break;
+                }
+            }
+        }
+        setValid(valid);
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.jface.dialogs.DialogPage#setVisible(boolean)
+     */
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+        if (visible && invalidFieldEditor != null) {
+            invalidFieldEditor.setFocus();
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.jface.preference.PreferencePage#performDefaults()
+     */
+    @Override
+    protected void performDefaults() {
+        if (fields != null) {
+            for (final FieldEditor field : fields) {
+                field.loadDefault();
+            }
+        }
+
+        checkState();
+        super.performDefaults();
+    }
+
+    /* (non-Javadoc)
+     * @see org.eclipse.jface.preference.PreferencePage#performOk()
+     */
+    @Override
+    public boolean performOk() {
+        if (fields != null) {
+            for (final FieldEditor field : fields) {
+                field.store();
+            }
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
This PR adds all the refactorings on the panel of preference and allows to set the refactoring by default or not. It affects only AutoRefactor->Automatic refactoring. All the refactoring can still be launched with AutoRefactor->Choose refactorings... It also removes two former options as they are overridden now.

The advantage is that some developers don't use some library like TestNG, JUnit or Android. They can disable those refactorings to speed up the plugin.