### PR TITLE
Missing code collection.add(). Closes #209

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/CollectionRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/CollectionRefactoring.java
@@ -412,12 +412,9 @@ public class CollectionRefactoring extends AbstractRefactoringRule {
     private boolean maybeReplaceSetContains(final IfStatement nodeToReplace, final Expression ifExpression,
             final Statement statement,
             final Statement oppositeStatement, final boolean negate) {
-        if (maybeReplaceSetContains(nodeToReplace, ifExpression, statement, oppositeStatement, negate, "add")
-                == VISIT_SUBTREE) {
-            return maybeReplaceSetContains(nodeToReplace, ifExpression, oppositeStatement, statement, !negate,
+        return maybeReplaceSetContains(nodeToReplace, ifExpression, statement, oppositeStatement, negate, "add")
+                &&  maybeReplaceSetContains(nodeToReplace, ifExpression, oppositeStatement, statement, !negate,
                     "remove");
-        }
-        return DO_NOT_VISIT_SUBTREE;
     }
 
     private boolean maybeReplaceSetContains(final IfStatement nodeToReplace, final Expression ifExpression,

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/CollectionSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/CollectionSample.java
@@ -219,7 +219,7 @@ public class CollectionSample {
         System.out.println(0 > col.size());
     }
 
-    public void replaceCheckOnSetContainsBeforeAdd(Set<String> col, String s) {
+    public void replaceCheckOnSetNotContainsBeforeAdd(Set<String> col, String s) {
         if (!col.contains(s)) {
             col.add(s);
             System.out.println("OK");
@@ -228,7 +228,7 @@ public class CollectionSample {
         }
     }
 
-    public void replaceCheckOnSetContainsBeforeAdd2(Set<String> col, String s) {
+    public void replaceCheckOnSetContainsBeforeAdd(Set<String> col, String s) {
         if (col.contains(s)) {
             System.out.println("KO");
         } else {
@@ -237,9 +237,57 @@ public class CollectionSample {
         }
     }
 
+    public void replaceCheckOnSetContainsOneAddStatement(Set<String> col, String s) {
+        if (col.contains(s)) {
+        } else {
+            col.add(s);
+        }
+    }
+
+    public void replaceCheckOnSetNotContainsOneAddStatement(Set<String> col, String s) {
+        if (!col.contains(s)) {
+            col.add(s);
+        }
+    }
+
+    public void replaceCheckOnSetContainsBeforeRemove(Set<String> col, String s) {
+        if (!col.contains(s)) {
+            System.out.println("KO");
+        } else {
+            col.remove(s);
+            System.out.println("OK");
+        }
+    }
+
+    public void replaceCheckOnSetNotContainsBeforeRemove(Set<String> col, String s) {
+        if (col.contains(s)) {
+            col.remove(s);
+            System.out.println("OK");
+        } else {
+            System.out.println("KO");
+        }
+    }
+
+    public void replaceCheckOnSetContainsOneRemoveStatement(Set<String> col, String s) {
+        if (col.contains(s)) {
+            col.remove(s);
+        }
+    }
+
+    public void replaceCheckOnSetNotContainsOneRemoveStatement(Set<String> col, String s) {
+        if (!col.contains(s)) {
+        } else {
+            col.remove(s);
+        }
+    }
+
     public void doNotReplaceWhenCheckedValueIsDifferent(Set<String> col) {
         if (!col.contains("this")) {
             col.add("that");
+            System.out.println("OK");
+        }
+        if (col.contains("this")) {
+            col.remove("that");
             System.out.println("OK");
         }
     }
@@ -247,6 +295,10 @@ public class CollectionSample {
     public void doNotReplaceWhenCollectionsAreDifferent(Set<String> col1, Set<String> col2) {
         if (!col1.contains("that")) {
             col2.add("that");
+            System.out.println("OK");
+        }
+        if (col1.contains("that")) {
+            col2.remove("that");
             System.out.println("OK");
         }
     }
@@ -257,6 +309,12 @@ public class CollectionSample {
             System.out.println("OK");
         } else {
             System.out.println("KO");
+        }
+        if (!col.contains(s)) {
+            System.out.println("KO");
+        } else {
+            col.remove(s);
+            System.out.println("OK");
         }
     }
 

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/CollectionSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/CollectionSample.java
@@ -194,7 +194,7 @@ public class CollectionSample {
         System.out.println(false);
     }
 
-    public void replaceCheckOnSetContainsBeforeAdd(Set<String> col, String s) {
+    public void replaceCheckOnSetNotContainsBeforeAdd(Set<String> col, String s) {
         if (col.add(s)) {
             System.out.println("OK");
         } else {
@@ -202,7 +202,7 @@ public class CollectionSample {
         }
     }
 
-    public void replaceCheckOnSetContainsBeforeAdd2(Set<String> col, String s) {
+    public void replaceCheckOnSetContainsBeforeAdd(Set<String> col, String s) {
         if (!col.add(s)) {
             System.out.println("KO");
         } else {
@@ -210,9 +210,45 @@ public class CollectionSample {
         }
     }
 
+    public void replaceCheckOnSetContainsOneAddStatement(Set<String> col, String s) {
+        col.add(s);
+    }
+
+    public void replaceCheckOnSetNotContainsOneAddStatement(Set<String> col, String s) {
+        col.add(s);
+    }
+
+    public void replaceCheckOnSetContainsBeforeRemove(Set<String> col, String s) {
+        if (!col.remove(s)) {
+            System.out.println("KO");
+        } else {
+            System.out.println("OK");
+        }
+    }
+
+    public void replaceCheckOnSetNotContainsBeforeRemove(Set<String> col, String s) {
+        if (col.remove(s)) {
+            System.out.println("OK");
+        } else {
+            System.out.println("KO");
+        }
+    }
+
+    public void replaceCheckOnSetContainsOneRemoveStatement(Set<String> col, String s) {
+        col.remove(s);
+    }
+
+    public void replaceCheckOnSetNotContainsOneRemoveStatement(Set<String> col, String s) {
+        col.remove(s);
+    }
+
     public void doNotReplaceWhenCheckedValueIsDifferent(Set<String> col) {
         if (!col.contains("this")) {
             col.add("that");
+            System.out.println("OK");
+        }
+        if (col.contains("this")) {
+            col.remove("that");
             System.out.println("OK");
         }
     }
@@ -220,6 +256,10 @@ public class CollectionSample {
     public void doNotReplaceWhenCollectionsAreDifferent(Set<String> col1, Set<String> col2) {
         if (!col1.contains("that")) {
             col2.add("that");
+            System.out.println("OK");
+        }
+        if (col1.contains("that")) {
+            col2.remove("that");
             System.out.println("OK");
         }
     }
@@ -230,6 +270,12 @@ public class CollectionSample {
             System.out.println("OK");
         } else {
             System.out.println("KO");
+        }
+        if (!col.contains(s)) {
+            System.out.println("KO");
+        } else {
+            col.remove(s);
+            System.out.println("OK");
         }
     }
 


### PR DESCRIPTION
Given:
``` Java
if (!col.contains(s)) {
    col.add(s);
}
```
When:
Refactor

Then:
``` Java
if (col.add(s)) {
}
```

And then
(nothing)

The `CollectionRefactor` starts to refactor and the `CommonCodeInIfElseStatementRefactoring` considers the test as useless... but it is active. This PR fixes the issue like this:
Given:
``` Java
if (!col.contains(s)) {
    col.add(s);
}
```

When:
Refactor

Then:
``` Java
col.add(s);
```

The PR also handles the case of `remove()`