### PR TITLE
[blocker] Statement badly moved before condition. Closes #208

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2013-2016 Jean-Noël Rouvignac - initial API and implementation
  * Copyright (C) 2016 Fabrice Tiercelin - Make sure we do not visit again modified nodes
+ * Copyright (C) 2016 Sameer Misger - Make SonarQube more happy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/CommonCodeInIfElseStatementRefactoring.java
@@ -3,7 +3,6 @@
  *
  * Copyright (C) 2013-2016 Jean-Noël Rouvignac - initial API and implementation
  * Copyright (C) 2016 Fabrice Tiercelin - Make sure we do not visit again modified nodes
- * Copyright (C) 2016 Sameer Misger - Make SonarQube more happy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,7 +49,7 @@ public class CommonCodeInIfElseStatementRefactoring extends AbstractRefactoringR
     public String getDescription() {
         return ""
             + "Factorizes common code in all if / else if / else statements"
-            + " either at the start of each blocks or at the end.\n"
+            + " at the end of each blocks.\n"
             + "Ultimately it can completely remove the if statement condition.";
     }
 
@@ -86,19 +85,9 @@ public class CommonCodeInIfElseStatementRefactoring extends AbstractRefactoringR
 
             boolean result = VISIT_SUBTREE;
 
-            // identify matching statements starting from the beginning of each case
-            for (int stmtIndex = 0; stmtIndex < minSize; stmtIndex++) {
-                if (!match(matcher, allCasesStmts, true, stmtIndex, 0, allCasesStmts.size())) {
-                    break;
-                }
-                this.ctx.getRefactorings().insertBefore(b.copy(caseStmts.get(stmtIndex)), node);
-                removeStmts(allCasesStmts, true, stmtIndex, removedCaseStmts);
-                result = DO_NOT_VISIT_SUBTREE;
-            }
-
             // identify matching statements starting from the end of each case
             for (int stmtIndex = 1; 0 <= minSize - stmtIndex; stmtIndex++) {
-                if (!match(matcher, allCasesStmts, false, stmtIndex, 0, allCasesStmts.size())
+                if (!match(matcher, allCasesStmts, stmtIndex, 0, allCasesStmts.size())
                         || anyContains(removedCaseStmts, allCasesStmts, stmtIndex)) {
                     break;
                 }
@@ -221,16 +210,16 @@ public class CommonCodeInIfElseStatementRefactoring extends AbstractRefactoringR
         }
     }
 
-    private boolean match(ASTMatcher matcher, List<List<Statement>> allCasesStmts, boolean matchForward, int stmtIndex,
-            int startIndex, int endIndex) {
+    private boolean match(ASTMatcher matcher, List<List<Statement>> allCasesStmts, int stmtIndex, int startIndex,
+            int endIndex) {
         if (startIndex == endIndex || startIndex == endIndex - 1) {
             return true;
         }
         final int comparisonIndex;
         if (endIndex - startIndex > 1) {
             final int pivotIndex = (endIndex + startIndex + 1) / 2;
-            if (!match(matcher, allCasesStmts, matchForward, stmtIndex, startIndex, pivotIndex)
-                    || !match(matcher, allCasesStmts, matchForward, stmtIndex, pivotIndex, endIndex)) {
+            if (!match(matcher, allCasesStmts, stmtIndex, startIndex, pivotIndex)
+                    || !match(matcher, allCasesStmts, stmtIndex, pivotIndex, endIndex)) {
                 return false;
             }
             comparisonIndex = pivotIndex;
@@ -240,12 +229,8 @@ public class CommonCodeInIfElseStatementRefactoring extends AbstractRefactoringR
 
         final List<Statement> caseStmts1 = allCasesStmts.get(startIndex);
         final List<Statement> caseStmts2 = allCasesStmts.get(comparisonIndex);
-        if (matchForward) {
-            return ASTHelper.match(matcher, caseStmts1.get(stmtIndex), caseStmts2.get(stmtIndex));
-        } else {
-            return ASTHelper.match(matcher, caseStmts1.get(caseStmts1.size() - stmtIndex),
+        return ASTHelper.match(matcher, caseStmts1.get(caseStmts1.size() - stmtIndex),
                     caseStmts2.get(caseStmts2.size() - stmtIndex));
-        }
     }
 
     private int minSize(List<List<Statement>> allCasesStmts) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/CommonCodeInIfElseStatementSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/CommonCodeInIfElseStatementSample.java
@@ -28,7 +28,7 @@ package org.autorefactor.refactoring.rules.samples_in;
 public class CommonCodeInIfElseStatementSample {
 
     /** no code at all, remove all */
-    public void emptyIfOrElseClauses(Boolean b, int i, int j) {
+    public void doNotRemoveIf(Boolean b, int i, int j) {
         if (b.booleanValue()) {
             System.out.println();
         } else {
@@ -36,7 +36,7 @@ public class CommonCodeInIfElseStatementSample {
     }
 
     /** no common code, Do not remove anything */
-    public void ifElseRemoveIf(Boolean b, int i, int j) {
+    public void doNotRemoveIfElse(Boolean b, int i, int j) {
         if (b.booleanValue()) {
             i++;
         } else {
@@ -46,79 +46,56 @@ public class CommonCodeInIfElseStatementSample {
 
     /** common code: i++, Remove if statement */
     public void ifElseRemoveIfNoBrackets(Boolean b, int i) {
-        // keep this!
-        if (b.booleanValue())
-            // keep this comment
-            i++;
-        else
-            i++;
+        // keep this comment
+        i++;
     }
 
     /** common code: i++, Remove if statement */
     public void ifElseRemoveIf(Boolean b, int i) {
-        if (b.booleanValue()) {
-            // keep this comment
-            i++;
-        } else {
-            i++;
-        }
+        // keep this comment
+        i++;
     }
 
     /** common code: i++, Remove then case */
     public void ifElseRemoveThen(Boolean b, int i, int j) {
-        if (b.booleanValue()) {
-            // keep this comment
+        if (!b.booleanValue()) {
             i++;
-        } else {
-            // keep this comment
-            i++;
-            j++;
         }
+        // keep this comment
+        j++;
     }
 
     /** common code: i++, Remove else case */
     public void ifElseRemoveElse(Boolean b, int i, int j) {
         if (b.booleanValue()) {
-            // keep this comment
-            i++;
-            j++;
-        } else {
-            // keep this comment
             i++;
         }
+        // keep this comment
+        j++;
     }
 
     /**
-     * common code: put i++ before if statement, put l++ after if statement. Do
-     * not remove if statement.
+     * common code: put l++ after if statement. Do not remove if statement.
      */
-    public void ifElseRemoveIf(Boolean b, int i, int j, int k, int l) {
+    public void putAfterIfStatement(Boolean b, int i, int j, int k, int l) {
         if (b.booleanValue()) {
             // keep this comment
             i++;
             j++;
-            // keep this comment
-            l++;
         } else {
             // keep this comment
             i++;
             k++;
-            // keep this comment
-            l++;
         }
+        // keep this comment
+        l++;
     }
 
     /** only common code, Remove if statement */
     public void ifElseRemoveIfSeveralStatements(Boolean b, int i, int j) {
-        if (b.booleanValue()) {
-            // keep this comment
-            i++;
-            j++;
-        } else {
-            // keep this comment
-            i++;
-            j++;
-        }
+        // keep this comment
+        i++;
+        j++;
     }
 
     /** not all cases covered, Do not remove anything */
@@ -134,19 +111,9 @@ public class CommonCodeInIfElseStatementSample {
 
     /** only common code: remove if statement */
     public void ifElseIfElseRemoveIf(Boolean b, int i, int j) {
-        if (b.booleanValue()) {
-            // keep this comment
-            i++;
-            j++;
-        } else if (!b.booleanValue()) {
-            // keep this comment
-            i++;
-            j++;
-        } else {
-            // keep this comment
-            i++;
-            j++;
-        }
+        // keep this comment
+        i++;
+        j++;
     }
 
     public int doNotRefactorDifferentVariablesInReturn(boolean b) {
@@ -161,10 +128,8 @@ public class CommonCodeInIfElseStatementSample {
 
     public void refactorMethodInvocatoin(boolean b, Object o) {
         if (b) {
-            o.toString();
             System.out.println(b);
-        } else {
-            o.toString();
         }
+        o.toString();
     }
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/CommonCodeInIfElseStatementSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/CommonCodeInIfElseStatementSample.java
@@ -28,7 +28,7 @@ package org.autorefactor.refactoring.rules.samples_out;
 public class CommonCodeInIfElseStatementSample {
 
     /** no code at all, remove all */
-    public void emptyIfOrElseClauses(Boolean b, int i, int j) {
+    public void doNotRemoveIf(Boolean b, int i, int j) {
         if (b.booleanValue()) {
             System.out.println();
         } else {
@@ -36,7 +36,7 @@ public class CommonCodeInIfElseStatementSample {
     }
 
     /** no common code, Do not remove anything */
-    public void ifElseRemoveIf(Boolean b, int i, int j) {
+    public void doNotRemoveIfElse(Boolean b, int i, int j) {
         if (b.booleanValue()) {
             i++;
         } else {
@@ -58,32 +58,33 @@ public class CommonCodeInIfElseStatementSample {
 
     /** common code: i++, Remove then case */
     public void ifElseRemoveThen(Boolean b, int i, int j) {
-        // keep this comment
-        i++;
         if (!b.booleanValue()) {
-            j++;
+            i++;
         }
+        // keep this comment
+        j++;
     }
 
     /** common code: i++, Remove else case */
     public void ifElseRemoveElse(Boolean b, int i, int j) {
-        // keep this comment
-        i++;
         if (b.booleanValue()) {
-            j++;
+            i++;
         }
+        // keep this comment
+        j++;
     }
 
     /**
-     * common code: put i++ before if statement, put l++ after if statement. Do
-     * not remove if statement.
+     * common code: put l++ after if statement. Do not remove if statement.
      */
-    public void ifElseRemoveIf(Boolean b, int i, int j, int k, int l) {
-        // keep this comment
-        i++;
+    public void putAfterIfStatement(Boolean b, int i, int j, int k, int l) {
         if (b.booleanValue()) {
+            // keep this comment
+            i++;
             j++;
         } else {
+            // keep this comment
+            i++;
             k++;
         }
         // keep this comment
@@ -126,9 +127,9 @@ public class CommonCodeInIfElseStatementSample {
     }
 
     public void refactorMethodInvocatoin(boolean b, Object o) {
-        o.toString();
         if (b) {
             System.out.println(b);
         }
+        o.toString();
     }
 }


### PR DESCRIPTION
Given:
``` Java
int i = 0;
int j = 0;
if (i == 0) {
  i = 10;
  j = 20;
} else {
  i = 10;
  j = 30;
}
System.out.println(j);
```

When:
Refactor

Then:
``` Java
int i = 0;
int j = 0;
i = 10;
if (i == 0) {
  j = 20;
} else {
  j = 30;
}
System.out.println(j);
```

Expected:
`>> 30`

Actual:
`>> 20`

If we move a statement before an if condition, it can break the workflow. A statement can change the condition result and a condition can also be active. This PR suggests not to merge statements before a condition.