### PR TITLE
Merge conditional blocks

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/AllRefactoringRules.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/AllRefactoringRules.java
@@ -84,6 +84,7 @@ public final class AllRefactoringRules {
                 new DeadCodeEliminationRefactoring(),
                 new CollapseIfStatementRefactoring(),
                 new CommonCodeInIfElseStatementRefactoring(),
+                new MergeConditionalBlocksRefactoring(),
                 // TODO JNR complete it
                 // new GenerecizeRefactoring(),
                 new UseDiamondOperatorRefactoring(),

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/MergeConditionalBlocksRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/MergeConditionalBlocksRefactoring.java
@@ -86,7 +86,11 @@ public class MergeConditionalBlocksRefactoring extends AbstractRefactoringRule {
 
             r.replace(firstCondition, b.infixExpr(b.parenthesizeIfNeeded(b.copy(firstCondition)),
                     InfixExpression.Operator.CONDITIONAL_OR, b.parenthesizeIfNeeded(additionalCondition)));
-            r.replace(subNode, b.copy(remainingStatements));
+            if (remainingStatements != null) {
+                r.replace(subNode, b.copy(remainingStatements));
+            } else {
+                r.remove(subNode);
+            }
             return DO_NOT_VISIT_SUBTREE;
         }
         return VISIT_SUBTREE;

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/MergeConditionalBlocksRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/MergeConditionalBlocksRefactoring.java
@@ -1,0 +1,110 @@
+/*
+ * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
+ *
+ * Copyright (C) 2016 Fabrice Tiercelin - initial API and implementation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program under LICENSE-GNUGPL.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution under LICENSE-ECLIPSE, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.autorefactor.refactoring.rules;
+
+import java.util.List;
+
+import org.autorefactor.refactoring.ASTBuilder;
+import org.autorefactor.refactoring.ASTHelper;
+import org.autorefactor.refactoring.Refactorings;
+import org.autorefactor.refactoring.ASTBuilder.Copy;
+import org.eclipse.jdt.core.dom.ASTMatcher;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.Statement;
+
+import static org.autorefactor.refactoring.ASTHelper.*;
+
+/** See {@link #getDescription()} method. */
+public class MergeConditionalBlocksRefactoring extends AbstractRefactoringRule {
+    @Override
+    public String getDescription() {
+        return ""
+            + "Merge adjacent if / else if / else statements with same code block.";
+    }
+
+    @Override
+    public String getName() {
+        return "Merge conditional statements";
+    }
+
+    @Override
+    public boolean visit(IfStatement node) {
+        final Expression firstCondition = node.getExpression();
+        final List<Statement> ifCode = asList(node.getThenStatement());
+        final List<Statement> elseCode = asList(node.getElseStatement());
+
+        if (elseCode != null && elseCode.size() == 1 && elseCode.get(0) instanceof IfStatement) {
+            final IfStatement subNode = (IfStatement) elseCode.get(0);
+            final Expression secondCondition = subNode.getExpression();
+
+            return maybeMergeBlocks(firstCondition, ifCode, subNode, secondCondition, subNode.getThenStatement(),
+                    subNode.getElseStatement(), true)
+                    && maybeMergeBlocks(firstCondition, ifCode, subNode, secondCondition,
+                            subNode.getElseStatement(), subNode.getThenStatement(), false);
+        }
+        return VISIT_SUBTREE;
+    }
+
+    private boolean maybeMergeBlocks(final Expression firstCondition, final List<Statement> ifCode,
+            final IfStatement subNode, final Expression secondCondition, final Statement doubleStatements,
+            final Statement remainingStatements, final boolean isPositive) {
+        if (isSameCode(ifCode, asList(doubleStatements))) {
+            final ASTBuilder b = this.ctx.getASTBuilder();
+            final Refactorings r = this.ctx.getRefactorings();
+
+            final Expression additionalCondition;
+            if (isPositive) {
+                additionalCondition = b.copy(secondCondition);
+            } else {
+                additionalCondition = b.negate(secondCondition, Copy.COPY);
+            }
+
+            r.replace(firstCondition, b.infixExpr(b.parenthesizeIfNeeded(b.copy(firstCondition)),
+                    InfixExpression.Operator.CONDITIONAL_OR, b.parenthesizeIfNeeded(additionalCondition)));
+            r.replace(subNode, b.copy(remainingStatements));
+            return DO_NOT_VISIT_SUBTREE;
+        }
+        return VISIT_SUBTREE;
+    }
+
+    private boolean isSameCode(final List<Statement> referenceStatements, final List<Statement> comparedStatements) {
+        if (referenceStatements.size() != comparedStatements.size()) {
+            return false;
+        }
+
+        final ASTMatcher matcher = new ASTMatcher();
+
+        for (int codeLine = 0; codeLine < referenceStatements.size(); codeLine++) {
+            if (!ASTHelper.match(matcher, referenceStatements.get(codeLine),
+                    comparedStatements.get(codeLine))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/MergeConditionalBlocksSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/MergeConditionalBlocksSample.java
@@ -57,6 +57,18 @@ public class MergeConditionalBlocksSample {
         }
     }
 
+    /** Duplicate if and else if code, merge it */
+    public void duplicateIfAndElseIfWithoutElse(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        }
+    }
+
     /** Duplicate else if codes, merge it */
     public void duplicateIfAndElseIfAmongOther(int i) {
         // Keep this comment

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/MergeConditionalBlocksSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/MergeConditionalBlocksSample.java
@@ -1,0 +1,163 @@
+/*
+ * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
+ *
+ * Copyright (C) 2016 Fabrice Tiercelin - initial API and implementation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program under LICENSE-GNUGPL.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution under LICENSE-ECLIPSE, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.autorefactor.refactoring.rules.samples_in;
+
+public class MergeConditionalBlocksSample {
+
+    /** Duplicate if and else if code, merge it */
+    public void duplicateIfAndElseIf(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else code, merge it */
+    public void duplicateIfAndElse(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1) {
+            // Keep this comment also
+            System.out.println("Different");
+        } else {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        }
+    }
+
+    /** Duplicate else if codes, merge it */
+    public void duplicateIfAndElseIfAmongOther(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("A given code");
+        } if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 2) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void duplicateSingleStatement(int i) {
+        // Keep this comment
+        if (i == 0)
+            // Keep this comment too
+            System.out.println("Duplicate");
+        else if (i == 1)
+            // Keep this comment too
+            System.out.println("Duplicate");
+        else
+            // Keep this comment also
+            System.out.println("Different");
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void numerousDuplicateIfAndElseIf(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 2) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 3) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void complexIfAndElseIf(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1 || i == 2) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i > 10) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void longIfAndElseIf(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+            System.out.println("code");
+        } else if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+            System.out.println("code");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Different if and else if code, leave it */
+    public void doNotMergeSameCode(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+            System.out.println("but not only");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+}

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/MergeConditionalBlocksSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/MergeConditionalBlocksSample.java
@@ -1,0 +1,132 @@
+/*
+ * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
+ *
+ * Copyright (C) 2016 Fabrice Tiercelin - initial API and implementation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program under LICENSE-GNUGPL.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution under LICENSE-ECLIPSE, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.autorefactor.refactoring.rules.samples_out;
+
+public class MergeConditionalBlocksSample {
+
+    /** Duplicate if and else if code, merge it */
+    public void duplicateIfAndElseIf(int i) {
+        // Keep this comment
+        if ((i == 0) || (i == 1)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else code, merge it */
+    public void duplicateIfAndElse(int i) {
+        // Keep this comment
+        if ((i == 0) || !(i == 1)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate else if codes, merge it */
+    public void duplicateIfAndElseIfAmongOther(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("A given code");
+        } if ((i == 1) || (i == 2)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void duplicateSingleStatement(int i) {
+        // Keep this comment
+        if ((i == 0) || (i == 1))
+            // Keep this comment too
+            System.out.println("Duplicate");
+        else
+            // Keep this comment also
+            System.out.println("Different");
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void numerousDuplicateIfAndElseIf(int i) {
+        // Keep this comment
+        if ((((i == 0) || (i == 1)) || (i == 2)) || (i == 3)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void complexIfAndElseIf(int i) {
+        // Keep this comment
+        if (((i == 0) || (i == 1 || i == 2)) || (i > 10)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Duplicate if and else if code, merge it */
+    public void longIfAndElseIf(int i) {
+        // Keep this comment
+        if ((i == 0) || (i == 1)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+            System.out.println("code");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+
+    /** Different if and else if code, leave it */
+    public void doNotMergeSameCode(int i) {
+        // Keep this comment
+        if (i == 0) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        } else if (i == 1) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+            System.out.println("but not only");
+        } else {
+            // Keep this comment also
+            System.out.println("Different");
+        }
+    }
+}

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/MergeConditionalBlocksSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/MergeConditionalBlocksSample.java
@@ -51,6 +51,15 @@ public class MergeConditionalBlocksSample {
         }
     }
 
+    /** Duplicate if and else if code, merge it */
+    public void duplicateIfAndElseIfWithoutElse(int i) {
+        // Keep this comment
+        if ((i == 0) || (i == 1)) {
+            // Keep this comment too
+            System.out.println("Duplicate");
+        }
+    }
+
     /** Duplicate else if codes, merge it */
     public void duplicateIfAndElseIfAmongOther(int i) {
         // Keep this comment


### PR DESCRIPTION
Given:
``` Java
if (i == 0) {
    System.out.println("Duplicate");
} else if (i == 1) {
    System.out.println("Duplicate");
} else {
    System.out.println("Different");
}
```

When:
Refactor

Then:
``` Java
if ((i == 0) || (i == 1)) {
    System.out.println("Duplicate");
} else {
    System.out.println("Different");
}
```

It merges adjacent conditional blocks or ending else block. It is fully compliant with `CommonCodeInIfElseStatementRefactoring`. Both can be run in any order any number of times, the result will still be the same.