### PR TITLE
JUnit refactoring. Closes #207 and #246

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/AbstractUnitTestRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/AbstractUnitTestRefactoring.java
@@ -1,0 +1,364 @@
+/*
+ * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
+ *
+ * Copyright (C) 2015 Jean-Noël Rouvignac - initial API and implementation
+ * Copyright (C) 2016 Fabrice Tiercelin - Adapt for JUnit
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program under LICENSE-GNUGPL.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution under LICENSE-ECLIPSE, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.autorefactor.refactoring.rules;
+
+import java.util.List;
+
+import org.autorefactor.refactoring.ASTBuilder;
+import org.autorefactor.refactoring.Refactorings;
+import org.autorefactor.util.NotImplementedException;
+import org.autorefactor.util.Pair;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.PrefixExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
+
+import static org.autorefactor.refactoring.ASTHelper.*;
+import static org.eclipse.jdt.core.dom.ASTNode.*;
+import static org.eclipse.jdt.core.dom.InfixExpression.Operator.*;
+import static org.eclipse.jdt.core.dom.PrefixExpression.Operator.*;
+
+/**
+ * See {@link #getDescription()} method.
+ */
+public abstract class AbstractUnitTestRefactoring extends AbstractRefactoringRule {
+
+    /**
+     * The OBJECT constant.
+     */
+    protected static final String OBJECT = "java.lang.Object";
+
+    /**
+     * Return true if assertNotEquals can be used.
+     *
+     * @return True if assertNotEquals can be used.
+     */
+    protected abstract boolean canUseAssertNotEquals();
+
+    /**
+     * Get the actual value and then the expected value.
+     *
+     * @param leftValue
+     *            The left value
+     * @param rightValue
+     *            The right value
+     * @return The actual and the expected.
+     */
+    protected abstract Pair<Expression, Expression> getActualAndExpected(final Expression leftValue,
+            final Expression rightValue);
+
+    /**
+     * Invoke the method.
+     *
+     * @param b
+     *            The builder.
+     * @param copyOfMethod
+     *            The copy of the original method.
+     * @param methodName
+     *            methodName.
+     * @param copyOfActual
+     *            The copy of the actual value or null.
+     * @param copyOfExpected
+     *            The copy of the expected value or null.
+     * @param failureMessage
+     *            The original failure message or null.
+     * @return The method invocation object.
+     */
+    protected abstract MethodInvocation invokeMethod(final ASTBuilder b, final Expression copyOfMethod,
+            final String methodName, final Expression copyOfActual, final Expression copyOfExpected,
+            final Expression failureMessage);
+
+    @Override
+    public abstract boolean visit(MethodInvocation node);
+
+    @Override
+    public abstract boolean visit(IfStatement node);
+
+    /**
+     * Maybe refactor the statement.
+     *
+     * @param nodeToReplace
+     *            The node
+     * @param originalMethod
+     *            The method invocation
+     * @param isAssertTrue
+     *            True if assertTrue is used, False if assertFalse is used.
+     * @param condition
+     *            The condition on which the assert is based.
+     * @param failureMessage
+     *            The failure message or null.
+     * @param isRewriteNeeded
+     *            True if is the rewriting is needed.
+     * @return True if refactored
+     */
+    protected boolean maybeRefactorStatement(final ASTNode nodeToReplace, final MethodInvocation originalMethod,
+            final boolean isAssertTrue, final Expression condition, final Expression failureMessage,
+            final boolean isRewriteNeeded) {
+        Expression localCondition = condition;
+        boolean localIsAssertTrue = isAssertTrue;
+        boolean localIsRewriteNeeded = isRewriteNeeded;
+        PrefixExpression localConditionPe = as(localCondition, PrefixExpression.class);
+
+        while (hasOperator(localConditionPe, NOT)) {
+            localIsRewriteNeeded = true;
+
+            localIsAssertTrue = !localIsAssertTrue;
+            localCondition = as(localConditionPe.getOperand(), Expression.class);
+            localConditionPe = as(localCondition, PrefixExpression.class);
+        }
+
+        final InfixExpression conditionIe = as(localCondition, InfixExpression.class);
+        final MethodInvocation conditionMi = as(localCondition, MethodInvocation.class);
+        final Object constantValue = localCondition.resolveConstantExpressionValue();
+
+        return maybeRefactorAssertTrueOrFalse(nodeToReplace, originalMethod, localIsAssertTrue, localCondition,
+                conditionIe, conditionMi, constantValue, failureMessage, localIsRewriteNeeded);
+    }
+
+    private boolean maybeRefactorAssertTrueOrFalse(final ASTNode nodeToReplace, final MethodInvocation originalMethod,
+            final boolean isAssertTrue, final Expression condition, final InfixExpression conditionIe,
+            final MethodInvocation conditionMi, final Object constantValue, final Expression failureMessage,
+            final boolean isRewriteNeeded) {
+        if (conditionIe != null) {
+            if (hasOperator(conditionIe, EQUALS)) {
+                return maybeRefactorComparison(nodeToReplace, originalMethod, conditionIe, isAssertTrue, failureMessage,
+                        isRewriteNeeded);
+            } else if (hasOperator(conditionIe, NOT_EQUALS)) {
+                return maybeRefactorComparison(nodeToReplace, originalMethod, conditionIe, !isAssertTrue,
+                        failureMessage, isRewriteNeeded);
+            }
+        } else if (isMethod(conditionMi, OBJECT, "equals", OBJECT)) {
+            if (canUseAssertNotEquals() || isAssertTrue) {
+                final Pair<Expression, Expression> actualAndExpected = getActualAndExpected(conditionMi.getExpression(),
+                        arg0(conditionMi));
+                return maybeRefactorToAssertEquals(nodeToReplace, originalMethod, isAssertTrue,
+                        actualAndExpected.getFirst(), actualAndExpected.getSecond(), failureMessage, true);
+            }
+        } else if (constantValue instanceof Boolean) {
+            return maybeReplaceOrRemove(nodeToReplace, originalMethod, isAssertTrue ^ (Boolean) constantValue,
+                    failureMessage);
+        } else if (isRewriteNeeded) {
+            return refactorToAssertTrueOrFalse(nodeToReplace, originalMethod, failureMessage, condition, isAssertTrue);
+        }
+        return VISIT_SUBTREE;
+    }
+
+    private boolean refactorToAssertTrueOrFalse(final ASTNode nodeToReplace, final MethodInvocation originalMethod,
+            final Expression failureMessage, final Expression condition, final boolean isAssertTrue) {
+        final ASTBuilder b = this.ctx.getASTBuilder();
+        final Refactorings r = this.ctx.getRefactorings();
+        final Expression copyOfMethod = b.copyExpression(originalMethod);
+        final String methodName = isAssertTrue ? "assertTrue" : "assertFalse";
+
+        r.replace(nodeToReplace, invokeMethodOrStatement(nodeToReplace, b,
+                invokeMethod(b, copyOfMethod, methodName, b.copy(condition), null, failureMessage)));
+        return DO_NOT_VISIT_SUBTREE;
+    }
+
+    private boolean maybeReplaceOrRemove(final ASTNode nodeToReplace, final MethodInvocation originalMethod,
+            final boolean replace, final Expression failureMessage) {
+        final Refactorings r = this.ctx.getRefactorings();
+        if (replace) {
+            r.replace(nodeToReplace, invokeFail(nodeToReplace, originalMethod, failureMessage));
+            return DO_NOT_VISIT_SUBTREE;
+        } else if (nodeToReplace.getParent().getNodeType() == ASTNode.EXPRESSION_STATEMENT) {
+            r.remove(nodeToReplace.getParent());
+            return DO_NOT_VISIT_SUBTREE;
+        }
+        return VISIT_SUBTREE;
+    }
+
+    private MethodInvocation invokeFail(final ASTNode node, final MethodInvocation originalMethod,
+            final Expression failureMessage) {
+        final ASTBuilder b = this.ctx.getASTBuilder();
+        final List<Expression> args = arguments(originalMethod);
+        final Expression copyOfMethod = b.copyExpression(originalMethod);
+        if ((args.size() == 1) || (args.size() == 2)) {
+            return invokeMethod(b, copyOfMethod, "fail", null, null, failureMessage);
+        } else {
+            throw new NotImplementedException(node);
+        }
+    }
+
+    private boolean maybeRefactorComparison(final ASTNode nodeToReplace, final MethodInvocation originalMethod,
+            final InfixExpression ie, final boolean isAssertEquals, final Expression failureMessage,
+            final boolean isRewriteNeeded) {
+        final Pair<Expression, Expression> actualAndExpected = getActualAndExpected(ie.getLeftOperand(),
+                ie.getRightOperand());
+
+        if (isComparingObjects(ie) && !isNullLiteral(ie.getLeftOperand()) && !isNullLiteral(ie.getRightOperand())) {
+            final ASTBuilder b = this.ctx.getASTBuilder();
+            final Refactorings r = this.ctx.getRefactorings();
+            final Expression copyOfMethod = b.copyExpression(originalMethod);
+
+            final MethodInvocation newAssert = invokeMethod(b, copyOfMethod, getAssertName(isAssertEquals, "Same"),
+                    b.copy(actualAndExpected.getFirst()), b.copy(actualAndExpected.getSecond()), failureMessage);
+            r.replace(nodeToReplace, invokeMethodOrStatement(nodeToReplace, b, newAssert));
+            return DO_NOT_VISIT_SUBTREE;
+        } else {
+            return maybeRefactorToAssertEquals(nodeToReplace, originalMethod, isAssertEquals,
+                    actualAndExpected.getFirst(), actualAndExpected.getSecond(), failureMessage, true);
+        }
+    }
+
+    /**
+     * Maybe refactor the assert equals.
+     *
+     * @param nodeToReplace
+     *            The node to replace
+     * @param originalMethod
+     *            The node
+     * @param isAssertEquals
+     *            The is assert equals
+     * @param actualValue
+     *            The actual value
+     * @param expectedValue
+     *            The expected value
+     * @param failureMessage
+     *            The failure message
+     * @param isRewriteNeeded
+     *            True if is the rewriting is needed.
+     * @return The return
+     */
+    protected boolean maybeRefactorToAssertEquals(final ASTNode nodeToReplace, final MethodInvocation originalMethod,
+            final boolean isAssertEquals, final Expression actualValue, final Expression expectedValue,
+            final Expression failureMessage, final boolean isRewriteNeeded) {
+        final Refactorings r = this.ctx.getRefactorings();
+        final ASTBuilder b = this.ctx.getASTBuilder();
+
+        if (isNullLiteral(actualValue)) {
+            r.replace(nodeToReplace, invokeMethodOrStatement(nodeToReplace, b,
+                    invokeAssertNull(originalMethod, isAssertEquals, expectedValue, failureMessage)));
+            return DO_NOT_VISIT_SUBTREE;
+        } else if (isNullLiteral(expectedValue)) {
+            r.replace(nodeToReplace, invokeMethodOrStatement(nodeToReplace, b,
+                    invokeAssertNull(originalMethod, isAssertEquals, actualValue, failureMessage)));
+            return DO_NOT_VISIT_SUBTREE;
+        } else if ((isConstant(actualValue) || isVariableNamedExpected(actualValue))
+                && !isConstant(expectedValue) && !isVariableNamedExpected(expectedValue)) {
+            final Expression copyOfMethod = b.copyExpression(originalMethod);
+            final MethodInvocation newAssert = invokeMethod(b, copyOfMethod, getAssertName(isAssertEquals, "Equals"),
+                    b.copy(expectedValue), b.copy(actualValue), failureMessage);
+            r.replace(nodeToReplace, invokeMethodOrStatement(nodeToReplace, b, newAssert));
+            return DO_NOT_VISIT_SUBTREE;
+        } else if (isRewriteNeeded) {
+            final Expression copyOfMethod = b.copyExpression(originalMethod);
+            final MethodInvocation newAssert = invokeMethod(b, copyOfMethod, getAssertName(isAssertEquals, "Equals"),
+                    b.copy(actualValue), b.copy(expectedValue), failureMessage);
+            r.replace(nodeToReplace, invokeMethodOrStatement(nodeToReplace, b, newAssert));
+            return DO_NOT_VISIT_SUBTREE;
+        }
+        return VISIT_SUBTREE;
+    }
+
+    private boolean isVariableNamedExpected(final Expression expr) {
+        switch (expr.getNodeType()) {
+        case SIMPLE_NAME:
+            final SimpleName sn = (SimpleName) expr;
+            return levenshteinDistance(sn.getIdentifier().toLowerCase(), "expected") <= 3;
+
+        case QUALIFIED_NAME:
+            final QualifiedName qn = (QualifiedName) expr;
+            return isVariableNamedExpected(qn.getName());
+
+        default:
+            return false;
+        }
+    }
+
+    private String getAssertName(final boolean isPositive, final String assertType) {
+        return "assert" + (isPositive ? "" : "Not") + assertType;
+    }
+
+    private boolean isComparingObjects(final InfixExpression ie) {
+        return !isPrimitive(ie.getLeftOperand()) || !isPrimitive(ie.getRightOperand());
+    }
+
+    private ASTNode invokeMethodOrStatement(final ASTNode nodeToReplace, final ASTBuilder b,
+            final MethodInvocation newMethod) {
+        if (nodeToReplace instanceof Statement) {
+            // The new node should be also a statement
+            return b.toStmt(newMethod);
+        } else {
+            return newMethod;
+        }
+    }
+
+    private MethodInvocation invokeAssertNull(final MethodInvocation originalMethod, final boolean isPositive,
+            final Expression actual, final Expression failureMessage) {
+        final ASTBuilder b = this.ctx.getASTBuilder();
+        final Expression copyOfMethod = b.copyExpression(originalMethod);
+        final String methodName = getAssertName(isPositive, "Null");
+        final Expression copyOfActual = b.copy(actual);
+        return invokeMethod(b, copyOfMethod, methodName, copyOfActual, null, failureMessage);
+    }
+
+    /**
+     * Returns the levenshtein distance between the two provided strings.
+     * <p>
+     * Note: Implementation comes from wikipedia.
+     *
+     * @param s1
+     *            the first string to compare
+     * @param s2
+     *            the second string to compare
+     * @return the levenshtein distance between the two strings
+     * @see <a href=
+     *      "https://en.wikipedia.org/wiki/Levenshtein_distance#Iterative_with_full_matrix">
+     *      Iterative implementation with full matrix</a>
+     */
+    private static int levenshteinDistance(final String s1, final String s2) {
+        int s1Length = s1.length() + 1;
+        int s2Length = s2.length() + 1;
+
+        int[][] d = new int[s1Length][s2Length];
+        for (int i = 0; i < s1Length; i++) {
+            d[i][0] = i;
+        }
+        for (int j = 0; j < s2Length; j++) {
+            d[0][j] = j;
+        }
+
+        for (int i = 1; i < s1Length; i++) {
+            for (int j = 1; j < s2Length; j++) {
+                int cost = s1.charAt(i - 1) == s2.charAt(j - 1) ? 0 : 1;
+
+                int deleteCost = d[i - 1][j] + 1;
+                int insertCost = d[i][j - 1] + 1;
+                int substitutionCost = d[i - 1][j - 1] + cost;
+                d[i][j] = Math.min(Math.min(deleteCost, insertCost), substitutionCost);
+            }
+        }
+
+        return d[s1Length - 1][s2Length - 1];
+    }
+}

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/AllRefactoringRules.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/AllRefactoringRules.java
@@ -110,6 +110,7 @@ public final class AllRefactoringRules {
                 new RemoveSemiColonRefactoring(),
                 // FIXME it would be nice if it was only enabled when testng jar is detected for the project
                 new TestNGAssertRefactoring(),
+                new JUnitAssertRefactoring(),
                 new ReplaceQualifiedNamesBySimpleNamesRefactoring(),
                 new RemoveEmptyLinesRefactoring(),
                 new AndroidWakeLockRefactoring(),

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/JUnitAssertRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/JUnitAssertRefactoring.java
@@ -1,0 +1,147 @@
+/*
+ * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
+ *
+ * Copyright (C) 2016 Fabrice Tiercelin - initial API and implementation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program under LICENSE-GNUGPL.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution under LICENSE-ECLIPSE, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.autorefactor.refactoring.rules;
+
+import java.util.List;
+
+import org.autorefactor.refactoring.ASTBuilder;
+import org.autorefactor.util.Pair;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Statement;
+
+import static org.autorefactor.refactoring.ASTHelper.*;
+
+/**
+ * See {@link #getDescription()} method.
+ */
+public class JUnitAssertRefactoring extends AbstractUnitTestRefactoring {
+
+    private static final String[] PACKAGE_PATHES = new String[] { "junit.framework.", "org.junit." };
+
+    @Override
+    public String getDescription() {
+        return "Refactors to a proper use of JUnit assertions.";
+    }
+
+    @Override
+    public String getName() {
+        return "JUnit asserts";
+    }
+
+    @Override
+    protected boolean canUseAssertNotEquals() {
+        return false;
+    }
+
+    @Override
+    protected Pair<Expression, Expression> getActualAndExpected(final Expression leftValue,
+            final Expression rightValue) {
+        return Pair.of(rightValue, leftValue);
+    }
+
+    @Override
+    public boolean visit(MethodInvocation node) {
+        final List<Expression> args = arguments(node);
+        int i = 0;
+        boolean shouldVisit = VISIT_SUBTREE;
+        while (shouldVisit == VISIT_SUBTREE && i < PACKAGE_PATHES.length) {
+            shouldVisit = maybeRefactorMethod(node, PACKAGE_PATHES[i], args);
+            i++;
+        }
+        return shouldVisit;
+    }
+
+    private boolean maybeRefactorMethod(final MethodInvocation node, final String unitTestPackagePath,
+            final List<Expression> args) {
+        if (isMethod(node, unitTestPackagePath + "Assert", "assertTrue", "boolean")) {
+            return maybeRefactorStatement(node, node, true, args.get(0), null, false);
+        } else if (isMethod(node, unitTestPackagePath + "Assert", "assertTrue", "java.lang.String", "boolean")) {
+            return maybeRefactorStatement(node, node, true, args.get(1), args.get(0), false);
+        } else if (isMethod(node, unitTestPackagePath + "Assert", "assertFalse", "boolean")) {
+            return maybeRefactorStatement(node, node, false, args.get(0), null, false);
+        } else if (isMethod(node, unitTestPackagePath + "Assert", "assertFalse", "java.lang.String", "boolean")) {
+            return maybeRefactorStatement(node, node, false, args.get(1), args.get(0), false);
+        } else if (isMethod(node, unitTestPackagePath + "Assert", "assertEquals", OBJECT, OBJECT)
+                || isMethod(node, unitTestPackagePath + "Assert", "assertEquals", "long", "long")
+                || isMethod(node, unitTestPackagePath + "Assert", "assertEquals", "double", "double")) {
+            return maybeRefactorToAssertEquals(node, node, true, args.get(1), args.get(0), null, false);
+        } else if (isMethod(node, unitTestPackagePath + "Assert", "assertEquals", "java.lang.String", OBJECT, OBJECT)
+                || isMethod(node, unitTestPackagePath + "Assert", "assertEquals", "java.lang.String", "long", "long")
+                || isMethod(node, unitTestPackagePath + "Assert", "assertEquals", "java.lang.String", "double",
+                        "double")) {
+            return maybeRefactorToAssertEquals(node, node, true, args.get(2), args.get(1), args.get(0), false);
+        }
+        return VISIT_SUBTREE;
+    }
+
+    @Override
+    public boolean visit(IfStatement node) {
+        final List<Statement> stmts = asList(node.getThenStatement());
+        if (node.getElseStatement() == null && stmts.size() == 1) {
+            final MethodInvocation mi = asExpression(stmts.get(0), MethodInvocation.class);
+            int i = 0;
+            boolean shouldVisit = VISIT_SUBTREE;
+            while (shouldVisit == VISIT_SUBTREE && i < PACKAGE_PATHES.length) {
+                shouldVisit = maybeRefactorIf(node, mi, PACKAGE_PATHES[i]);
+                i++;
+            }
+            return shouldVisit;
+        }
+        return VISIT_SUBTREE;
+    }
+
+    private boolean maybeRefactorIf(final IfStatement node, final MethodInvocation mi,
+            final String unitTestPackagePath) {
+        if (isMethod(mi, unitTestPackagePath + "Assert", "fail")) {
+            return maybeRefactorStatement(node, mi, false, node.getExpression(), null, true);
+        } else if (isMethod(mi, unitTestPackagePath + "Assert", "fail", "java.lang.String")) {
+            return maybeRefactorStatement(node, mi, false, node.getExpression(), arguments(mi).get(0), true);
+        }
+        return VISIT_SUBTREE;
+    }
+
+    @Override
+    protected MethodInvocation invokeMethod(final ASTBuilder b, final Expression copyOfExpr, final String methodName,
+            final Expression copyOfActual, final Expression copyOfExpected, final Expression failureMessage) {
+        if (failureMessage == null) {
+            if (copyOfActual == null) {
+                return b.invoke(copyOfExpr, methodName);
+            } else if (copyOfExpected == null) {
+                return b.invoke(copyOfExpr, methodName, copyOfActual);
+            } else {
+                return b.invoke(copyOfExpr, methodName, copyOfExpected, copyOfActual);
+            }
+        } else if (copyOfActual == null) {
+            return b.invoke(copyOfExpr, methodName, b.copy(failureMessage));
+        } else if (copyOfExpected == null) {
+            return b.invoke(copyOfExpr, methodName, b.copy(failureMessage), copyOfActual);
+        } else {
+            return b.invoke(copyOfExpr, methodName, b.copy(failureMessage), copyOfExpected, copyOfActual);
+        }
+    }
+}

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/JUnitAssertRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/JUnitAssertRefactoring.java
@@ -126,7 +126,8 @@ public class JUnitAssertRefactoring extends AbstractUnitTestRefactoring {
     }
 
     @Override
-    protected MethodInvocation invokeMethod(final ASTBuilder b, final Expression copyOfExpr, final String methodName,
+    protected MethodInvocation invokeQualifiedMethod(final ASTBuilder b, final Expression copyOfExpr,
+            final String methodName,
             final Expression copyOfActual, final Expression copyOfExpected, final Expression failureMessage) {
         if (failureMessage == null) {
             if (copyOfActual == null) {

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/TestNGAssertRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/TestNGAssertRefactoring.java
@@ -82,7 +82,7 @@ public class TestNGAssertRefactoring extends AbstractUnitTestRefactoring {
             // we have not found testng yet for this file, go on looking for it
             canUseAssertNotEquals = canUseAssertNotEquals(node);
         }
-        return VISIT_SUBTREE;
+        return super.visit(node);
     }
 
     private boolean canUseAssertNotEquals(final ImportDeclaration node) {

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/TestNGAssertRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/TestNGAssertRefactoring.java
@@ -158,7 +158,8 @@ public class TestNGAssertRefactoring extends AbstractUnitTestRefactoring {
     }
 
     @Override
-    protected MethodInvocation invokeMethod(final ASTBuilder b, final Expression copyOfExpr, final String methodName,
+    protected MethodInvocation invokeQualifiedMethod(final ASTBuilder b, final Expression copyOfExpr,
+            final String methodName,
             final Expression copyOfActual, final Expression copyOfExpected, final Expression failureMessage) {
         if (failureMessage == null) {
             if (copyOfActual == null) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/JUnitAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/JUnitAssertSample.java
@@ -1,8 +1,7 @@
 /*
  * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
  *
- * Copyright (C) 2015 Jean-Noël Rouvignac - initial API and implementation
- * Copyright (C) 2016 Fabrice Tiercelin - include more cases
+ * Copyright (C) 2016 Fabrice Tiercelin - initial API and implementation
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,247 +25,246 @@
  */
 package org.autorefactor.refactoring.rules.samples_in;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
-import static org.testng.Assert.*;
+import static org.junit.Assert.*;
 
-import org.testng.Assert;
+import org.junit.Assert;
 
-public class TestNGAssertSample {
+public class JUnitAssertSample {
 
     private static final int FOURTYTWO = 42;
 
     public void shouldRefactorWithPrimitives(int i1, int i2) throws Exception {
         Assert.assertTrue(i1 == i2);
-        Assert.assertTrue(i1 == i2, "Failure message to keep");
-        Assert.assertTrue(i1 != i2);
-        Assert.assertTrue(i1 != i2, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", i1 == i2);
         Assert.assertFalse(i1 != i2);
-        Assert.assertFalse(i1 != i2, "Failure message to keep");
-        Assert.assertFalse(i1 == i2);
-        Assert.assertFalse(i1 == i2, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", i1 != i2);
 
         assertTrue(i1 == i2);
-        assertTrue(i1 == i2, "Failure message to keep");
-        assertTrue(i1 != i2);
-        assertTrue(i1 != i2, "Failure message to keep");
+        assertTrue("Failure message to keep", i1 == i2);
         assertFalse(i1 != i2);
-        assertFalse(i1 != i2, "Failure message to keep");
-        assertFalse(i1 == i2);
-        assertFalse(i1 == i2, "Failure message to keep");
+        assertFalse("Failure message to keep", i1 != i2);
     }
 
     public void shouldRefactorFailures() throws Exception {
         Assert.assertTrue(false);
-        Assert.assertTrue(false, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", false);
         Assert.assertFalse(true);
-        Assert.assertFalse(true, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", true);
 
         assertTrue(false);
-        assertTrue(false, "Failure message to keep");
+        assertTrue("Failure message to keep", false);
         assertFalse(true);
-        assertFalse(true, "Failure message to keep");
+        assertFalse("Failure message to keep", true);
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
         Assert.assertTrue(true);
-        Assert.assertTrue(true, "Failure message to keep");
+        Assert.assertTrue("Useless message", true);
         Assert.assertFalse(false);
-        Assert.assertFalse(false, "Failure message to keep");
+        Assert.assertFalse("Useless message", false);
 
         assertTrue(true);
-        assertTrue(true, "Failure message to keep");
+        assertTrue("Useless message", true);
         assertFalse(false);
-        assertFalse(false, "Failure message to keep");
+        assertFalse("Useless message", false);
     }
 
     public void shouldRefactorNegatedConditions(boolean b) throws Exception {
         Assert.assertTrue(!b);
-        Assert.assertTrue(!b, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", !b);
         Assert.assertFalse(!b);
-        Assert.assertFalse(!b, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", !b);
 
         assertTrue(!b);
-        assertTrue(!b, "Failure message to keep");
+        assertTrue("Failure message to keep", !b);
         assertFalse(!b);
-        assertFalse(!b, "Failure message to keep");
+        assertFalse("Failure message to keep", !b);
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
         Assert.assertTrue(o1 == o2);
-        Assert.assertTrue(o1 == o2, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", o1 == o2);
         Assert.assertTrue(o1 != o2);
-        Assert.assertTrue(o1 != o2, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", o1 != o2);
         Assert.assertFalse(o1 != o2);
-        Assert.assertFalse(o1 != o2, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", o1 != o2);
         Assert.assertFalse(o1 == o2);
-        Assert.assertFalse(o1 == o2, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", o1 == o2);
 
         assertTrue(o1 == o2);
-        assertTrue(o1 == o2, "Failure message to keep");
+        assertTrue("Failure message to keep", o1 == o2);
         assertTrue(o1 != o2);
-        assertTrue(o1 != o2, "Failure message to keep");
+        assertTrue("Failure message to keep", o1 != o2);
         assertFalse(o1 != o2);
-        assertFalse(o1 != o2, "Failure message to keep");
+        assertFalse("Failure message to keep", o1 != o2);
         assertFalse(o1 == o2);
-        assertFalse(o1 == o2, "Failure message to keep");
+        assertFalse("Failure message to keep", o1 == o2);
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
         Assert.assertTrue(o1.equals(o2));
-        Assert.assertTrue(o1.equals(o2), "Failure message to keep");
-        Assert.assertTrue(!(o1.equals(o2)));
-        Assert.assertTrue(!(o1.equals(o2)), "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", o1.equals(o2));
         Assert.assertFalse(!(o1.equals(o2)));
-        Assert.assertFalse(!(o1.equals(o2)), "Failure message to keep");
-        Assert.assertFalse(o1.equals(o2));
-        Assert.assertFalse(o1.equals(o2), "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", !(o1.equals(o2)));
 
         assertTrue(o1.equals(o2));
-        assertTrue(o1.equals(o2), "Failure message to keep");
-        assertTrue(!(o1.equals(o2)));
-        assertTrue(!(o1.equals(o2)), "Failure message to keep");
+        assertTrue("Failure message to keep", o1.equals(o2));
         assertFalse(!(o1.equals(o2)));
-        assertFalse(!(o1.equals(o2)), "Failure message to keep");
-        assertFalse(o1.equals(o2));
-        assertFalse(o1.equals(o2), "Failure message to keep");
+        assertFalse("Failure message to keep", !(o1.equals(o2)));
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
         Assert.assertTrue(null == o);
-        Assert.assertTrue(null == o, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", null == o);
         Assert.assertTrue(null != o);
-        Assert.assertTrue(null != o, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", null != o);
         Assert.assertFalse(null != o);
-        Assert.assertFalse(null != o, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", null != o);
         Assert.assertFalse(null == o);
-        Assert.assertFalse(null == o, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", null == o);
 
         assertTrue(null == o);
-        assertTrue(null == o, "Failure message to keep");
+        assertTrue("Failure message to keep", null == o);
         assertTrue(null != o);
-        assertTrue(null != o, "Failure message to keep");
+        assertTrue("Failure message to keep", null != o);
         assertFalse(null != o);
-        assertFalse(null != o, "Failure message to keep");
+        assertFalse("Failure message to keep", null != o);
         assertFalse(null == o);
-        assertFalse(null == o, "Failure message to keep");
+        assertFalse("Failure message to keep", null == o);
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
         Assert.assertTrue(o == null);
-        Assert.assertTrue(o == null, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", o == null);
         Assert.assertTrue(o != null);
-        Assert.assertTrue(o != null, "Failure message to keep");
+        Assert.assertTrue("Failure message to keep", o != null);
         Assert.assertFalse(o != null);
-        Assert.assertFalse(o != null, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", o != null);
         Assert.assertFalse(o == null);
-        Assert.assertFalse(o == null, "Failure message to keep");
+        Assert.assertFalse("Failure message to keep", o == null);
 
         assertTrue(o == null);
-        assertTrue(o == null, "Failure message to keep");
+        assertTrue("Failure message to keep", o == null);
         assertTrue(o != null);
-        assertTrue(o != null, "Failure message to keep");
+        assertTrue("Failure message to keep", o != null);
         assertFalse(o != null);
-        assertFalse(o != null, "Failure message to keep");
+        assertFalse("Failure message to keep", o != null);
         assertFalse(o == null);
-        assertFalse(o == null, "Failure message to keep");
+        assertFalse("Failure message to keep", o == null);
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
         Assert.assertEquals(null, o);
-        Assert.assertEquals(null, o, "Failure message to keep");
-        Assert.assertNotEquals(null, o);
-        Assert.assertNotEquals(null, o, "Failure message to keep");
+        Assert.assertEquals("Failure message to keep", null, o);
 
         assertEquals(null, o);
-        assertEquals(null, o, "Failure message to keep");
-        assertNotEquals(null, o);
-        assertNotEquals(null, o, "Failure message to keep");
+        assertEquals("Failure message to keep", null, o);
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
         Assert.assertEquals(o, null);
-        Assert.assertEquals(o, null, "Failure message to keep");
-        Assert.assertNotEquals(o, null);
-        Assert.assertNotEquals(o, null, "Failure message to keep");
+        Assert.assertEquals("Failure message to keep", o, null);
 
         assertEquals(o, null);
-        assertEquals(o, null, "Failure message to keep");
-        assertNotEquals(o, null);
-        assertNotEquals(o, null, "Failure message to keep");
+        assertEquals("Failure message to keep", o, null);
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(42, o);
-        Assert.assertEquals(42, o, "Failure message to keep");
-        Assert.assertNotEquals(42, o);
-        Assert.assertNotEquals(42, o, "Failure message to keep");
+        Assert.assertEquals(o, 42);
+        Assert.assertEquals("Failure message to keep", o, 42);
 
-        assertEquals(42, o);
-        assertEquals(42, o, "Failure message to keep");
-        assertNotEquals(42, o);
-        assertNotEquals(42, o, "Failure message to keep");
+        assertEquals(o, 42);
+        assertEquals("Failure message to keep", o, 42);
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(o, 42);
-        Assert.assertEquals(o, 42, "Failure message to keep");
-        Assert.assertNotEquals(o, 42);
-        Assert.assertNotEquals(o, 42, "Failure message to keep");
+        Assert.assertEquals(42, o);
+        Assert.assertEquals("Failure message to keep", 42, o);
 
-        assertEquals(o, 42);
-        assertEquals(o, 42, "Failure message to keep");
-        assertNotEquals(o, 42);
-        assertNotEquals(o, 42, "Failure message to keep");
+        assertEquals(42, o);
+        assertEquals("Failure message to keep", 42, o);
     }
 
     public void shouldMoveConstantAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(FOURTYTWO, o);
-        Assert.assertEquals(FOURTYTWO, o, "Failure message to keep");
-        Assert.assertNotEquals(FOURTYTWO, o);
-        Assert.assertNotEquals(FOURTYTWO, o, "Failure message to keep");
+        Assert.assertEquals(o, FOURTYTWO);
+        Assert.assertEquals("Failure message to keep", o, FOURTYTWO);
 
-        assertEquals(FOURTYTWO, o);
-        assertEquals(FOURTYTWO, o, "Failure message to keep");
-        assertNotEquals(FOURTYTWO, o);
-        assertNotEquals(FOURTYTWO, o, "Failure message to keep");
+        assertEquals(o, FOURTYTWO);
+        assertEquals("Failure message to keep", o, FOURTYTWO);
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(o, FOURTYTWO);
-        Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
-        Assert.assertNotEquals(o, FOURTYTWO);
-        Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+        Assert.assertEquals(FOURTYTWO, o);
+        Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
 
-        assertEquals(o, FOURTYTWO);
-        assertEquals(o, FOURTYTWO, "Failure message to keep");
-        assertNotEquals(o, FOURTYTWO);
-        assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+        assertEquals(FOURTYTWO, o);
+        assertEquals("Failure message to keep", FOURTYTWO, o);
     }
 
-    public void shouldMoveExpectedVariableAsExpectedArgWithEquals(Object o, int expected) throws Exception {
-        Assert.assertEquals(expected, o);
-        Assert.assertEquals(expected, o, "Failure message to keep");
-        Assert.assertNotEquals(expected, o);
-        Assert.assertNotEquals(expected, o, "Failure message to keep");
+    public void shouldMoveExpectedObjectAsExpectedArgWithEquals(Object o, int expected) throws Exception {
+        Assert.assertEquals(o, expected);
+        Assert.assertEquals("Failure message to keep", o, expected);
 
-        assertEquals(expected, o);
-        assertEquals(expected, o, "Failure message to keep");
-        assertNotEquals(expected, o);
-        assertNotEquals(expected, o, "Failure message to keep");
+        assertEquals(o, expected);
+        assertEquals("Failure message to keep", o, expected);
 
         // tests that this works according to levenshtein distance
+        int expceted = 0;
+        assertEquals(o, expceted);
+    }
+
+    public void doNotRefactorExpectedObjectAsExpectedArgWithEquals(Object o, int expected) throws Exception {
+        Assert.assertEquals(expected, o);
+        Assert.assertEquals("Failure message to keep", expected, o);
+
+        assertEquals(expected, o);
+        assertEquals("Failure message to keep", expected, o);
+
         int expceted = 0;
         assertEquals(expceted, o);
     }
 
-    public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
-        if (i1 == i2) {
+    public void shouldMoveExpectedLongAsExpectedArgWithEquals(long l, long expected) throws Exception {
+        Assert.assertEquals(l, expected);
+        Assert.assertEquals("Failure message to keep", l, expected);
+
+        assertEquals(l, expected);
+        assertEquals("Failure message to keep", l, expected);
+
+        // tests that this works according to levenshtein distance
+        int expceted = 0;
+        assertEquals(l, expceted);
+    }
+
+    public void shouldMoveExpectedDoubleAsExpectedArgWithEquals(double d, double expected) throws Exception {
+        Assert.assertEquals(d, expected);
+        Assert.assertEquals("Failure message to keep", d, expected);
+
+        assertEquals(d, expected);
+        assertEquals("Failure message to keep", d, expected);
+
+        // tests that this works according to levenshtein distance
+        int expceted = 0;
+        assertEquals(d, expceted);
+    }
+
+    public void shouldRefactorIfOnBoolean(boolean b) throws Exception {
+        if (b) {
             Assert.fail();
         }
-        if (i1 == i2) {
+        if (b) {
             Assert.fail("Failure message to keep");
         }
+
+        if (!b) {
+            fail();
+        }
+        if (!b) {
+            fail("Failure message to keep");
+        }
+    }
+
+    public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
         if (i1 != i2) {
             Assert.fail();
         }
@@ -274,12 +272,6 @@ public class TestNGAssertSample {
             Assert.fail("Failure message to keep");
         }
 
-        if (i1 == i2) {
-            fail();
-        }
-        if (i1 == i2) {
-            fail("Failure message to keep");
-        }
         if (i1 != i2) {
             fail();
         }
@@ -369,12 +361,6 @@ public class TestNGAssertSample {
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
-        if (o1.equals(o2)) {
-            Assert.fail();
-        }
-        if (o1.equals(o2)) {
-            Assert.fail("Failure message to keep");
-        }
         if (!o1.equals(o2)) {
             Assert.fail();
         }
@@ -382,12 +368,6 @@ public class TestNGAssertSample {
             Assert.fail("Failure message to keep");
         }
 
-        if (o1.equals(o2)) {
-            fail();
-        }
-        if (o1.equals(o2)) {
-            fail("Failure message to keep");
-        }
         if (!o1.equals(o2)) {
             fail();
         }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/TestNGAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/TestNGAssertSample.java
@@ -37,175 +37,166 @@ public class TestNGAssertSample {
     private static final int FOURTYTWO = 42;
 
     public void shouldRefactorWithPrimitives(int i1, int i2) throws Exception {
-        Assert.assertTrue(i1 == i2);
-        Assert.assertTrue(i1 == i2, "Failure message to keep");
-        Assert.assertTrue(i1 != i2);
-        Assert.assertTrue(i1 != i2, "Failure message to keep");
-        Assert.assertFalse(i1 != i2);
-        Assert.assertFalse(i1 != i2, "Failure message to keep");
-        Assert.assertFalse(i1 == i2);
-        Assert.assertFalse(i1 == i2, "Failure message to keep");
+        Assert.assertEquals(i1, i2);
+        Assert.assertEquals(i1, i2, "Failure message to keep");
+        Assert.assertNotEquals(i1, i2);
+        Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        Assert.assertEquals(i1, i2);
+        Assert.assertEquals(i1, i2, "Failure message to keep");
+        Assert.assertNotEquals(i1, i2);
+        Assert.assertNotEquals(i1, i2, "Failure message to keep");
 
-        assertTrue(i1 == i2);
-        assertTrue(i1 == i2, "Failure message to keep");
-        assertTrue(i1 != i2);
-        assertTrue(i1 != i2, "Failure message to keep");
-        assertFalse(i1 != i2);
-        assertFalse(i1 != i2, "Failure message to keep");
-        assertFalse(i1 == i2);
-        assertFalse(i1 == i2, "Failure message to keep");
+        org.testng.Assert.assertEquals(i1, i2);
+        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i1, i2);
+        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertEquals(i1, i2);
+        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i1, i2);
+        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
     }
 
     public void shouldRefactorFailures() throws Exception {
-        Assert.assertTrue(false);
-        Assert.assertTrue(false, "Failure message to keep");
-        Assert.assertFalse(true);
-        Assert.assertFalse(true, "Failure message to keep");
+        Assert.fail();
+        Assert.fail("Failure message to keep");
+        Assert.fail();
+        Assert.fail("Failure message to keep");
 
-        assertTrue(false);
-        assertTrue(false, "Failure message to keep");
-        assertFalse(true);
-        assertFalse(true, "Failure message to keep");
+        org.testng.Assert.fail();
+        org.testng.Assert.fail("Failure message to keep");
+        org.testng.Assert.fail();
+        org.testng.Assert.fail("Failure message to keep");
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
-        Assert.assertTrue(true);
-        Assert.assertTrue(true, "Failure message to keep");
-        Assert.assertFalse(false);
-        Assert.assertFalse(false, "Failure message to keep");
-
-        assertTrue(true);
-        assertTrue(true, "Failure message to keep");
-        assertFalse(false);
-        assertFalse(false, "Failure message to keep");
     }
 
     public void shouldRefactorNegatedConditions(boolean b) throws Exception {
-        Assert.assertTrue(!b);
-        Assert.assertTrue(!b, "Failure message to keep");
-        Assert.assertFalse(!b);
-        Assert.assertFalse(!b, "Failure message to keep");
+        Assert.assertFalse(b);
+        Assert.assertFalse(b, "Failure message to keep");
+        Assert.assertTrue(b);
+        Assert.assertTrue(b, "Failure message to keep");
 
-        assertTrue(!b);
-        assertTrue(!b, "Failure message to keep");
-        assertFalse(!b);
-        assertFalse(!b, "Failure message to keep");
+        org.testng.Assert.assertFalse(b);
+        org.testng.Assert.assertFalse(b, "Failure message to keep");
+        org.testng.Assert.assertTrue(b);
+        org.testng.Assert.assertTrue(b, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
-        Assert.assertTrue(o1 == o2);
-        Assert.assertTrue(o1 == o2, "Failure message to keep");
-        Assert.assertTrue(o1 != o2);
-        Assert.assertTrue(o1 != o2, "Failure message to keep");
-        Assert.assertFalse(o1 != o2);
-        Assert.assertFalse(o1 != o2, "Failure message to keep");
-        Assert.assertFalse(o1 == o2);
-        Assert.assertFalse(o1 == o2, "Failure message to keep");
+        Assert.assertSame(o1, o2);
+        Assert.assertSame(o1, o2, "Failure message to keep");
+        Assert.assertNotSame(o1, o2);
+        Assert.assertNotSame(o1, o2, "Failure message to keep");
+        Assert.assertSame(o1, o2);
+        Assert.assertSame(o1, o2, "Failure message to keep");
+        Assert.assertNotSame(o1, o2);
+        Assert.assertNotSame(o1, o2, "Failure message to keep");
 
-        assertTrue(o1 == o2);
-        assertTrue(o1 == o2, "Failure message to keep");
-        assertTrue(o1 != o2);
-        assertTrue(o1 != o2, "Failure message to keep");
-        assertFalse(o1 != o2);
-        assertFalse(o1 != o2, "Failure message to keep");
-        assertFalse(o1 == o2);
-        assertFalse(o1 == o2, "Failure message to keep");
+        org.testng.Assert.assertSame(o1, o2);
+        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotSame(o1, o2);
+        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertSame(o1, o2);
+        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotSame(o1, o2);
+        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
-        Assert.assertTrue(o1.equals(o2));
-        Assert.assertTrue(o1.equals(o2), "Failure message to keep");
-        Assert.assertTrue(!(o1.equals(o2)));
-        Assert.assertTrue(!(o1.equals(o2)), "Failure message to keep");
-        Assert.assertFalse(!(o1.equals(o2)));
-        Assert.assertFalse(!(o1.equals(o2)), "Failure message to keep");
-        Assert.assertFalse(o1.equals(o2));
-        Assert.assertFalse(o1.equals(o2), "Failure message to keep");
+        Assert.assertEquals(o1, o2);
+        Assert.assertEquals(o1, o2, "Failure message to keep");
+        Assert.assertNotEquals(o1, o2);
+        Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        Assert.assertEquals(o1, o2);
+        Assert.assertEquals(o1, o2, "Failure message to keep");
+        Assert.assertNotEquals(o1, o2);
+        Assert.assertNotEquals(o1, o2, "Failure message to keep");
 
-        assertTrue(o1.equals(o2));
-        assertTrue(o1.equals(o2), "Failure message to keep");
-        assertTrue(!(o1.equals(o2)));
-        assertTrue(!(o1.equals(o2)), "Failure message to keep");
-        assertFalse(!(o1.equals(o2)));
-        assertFalse(!(o1.equals(o2)), "Failure message to keep");
-        assertFalse(o1.equals(o2));
-        assertFalse(o1.equals(o2), "Failure message to keep");
+        org.testng.Assert.assertEquals(o1, o2);
+        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o1, o2);
+        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertEquals(o1, o2);
+        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o1, o2);
+        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
-        Assert.assertTrue(null == o);
-        Assert.assertTrue(null == o, "Failure message to keep");
-        Assert.assertTrue(null != o);
-        Assert.assertTrue(null != o, "Failure message to keep");
-        Assert.assertFalse(null != o);
-        Assert.assertFalse(null != o, "Failure message to keep");
-        Assert.assertFalse(null == o);
-        Assert.assertFalse(null == o, "Failure message to keep");
+        Assert.assertNull(o);
+        Assert.assertNull(o, "Failure message to keep");
+        Assert.assertNotNull(o);
+        Assert.assertNotNull(o, "Failure message to keep");
+        Assert.assertNull(o);
+        Assert.assertNull(o, "Failure message to keep");
+        Assert.assertNotNull(o);
+        Assert.assertNotNull(o, "Failure message to keep");
 
-        assertTrue(null == o);
-        assertTrue(null == o, "Failure message to keep");
-        assertTrue(null != o);
-        assertTrue(null != o, "Failure message to keep");
-        assertFalse(null != o);
-        assertFalse(null != o, "Failure message to keep");
-        assertFalse(null == o);
-        assertFalse(null == o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
-        Assert.assertTrue(o == null);
-        Assert.assertTrue(o == null, "Failure message to keep");
-        Assert.assertTrue(o != null);
-        Assert.assertTrue(o != null, "Failure message to keep");
-        Assert.assertFalse(o != null);
-        Assert.assertFalse(o != null, "Failure message to keep");
-        Assert.assertFalse(o == null);
-        Assert.assertFalse(o == null, "Failure message to keep");
+        Assert.assertNull(o);
+        Assert.assertNull(o, "Failure message to keep");
+        Assert.assertNotNull(o);
+        Assert.assertNotNull(o, "Failure message to keep");
+        Assert.assertNull(o);
+        Assert.assertNull(o, "Failure message to keep");
+        Assert.assertNotNull(o);
+        Assert.assertNotNull(o, "Failure message to keep");
 
-        assertTrue(o == null);
-        assertTrue(o == null, "Failure message to keep");
-        assertTrue(o != null);
-        assertTrue(o != null, "Failure message to keep");
-        assertFalse(o != null);
-        assertFalse(o != null, "Failure message to keep");
-        assertFalse(o == null);
-        assertFalse(o == null, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
-        Assert.assertEquals(null, o);
-        Assert.assertEquals(null, o, "Failure message to keep");
-        Assert.assertNotEquals(null, o);
-        Assert.assertNotEquals(null, o, "Failure message to keep");
+        Assert.assertNull(o);
+        Assert.assertNull(o, "Failure message to keep");
+        Assert.assertNotNull(o);
+        Assert.assertNotNull(o, "Failure message to keep");
 
-        assertEquals(null, o);
-        assertEquals(null, o, "Failure message to keep");
-        assertNotEquals(null, o);
-        assertNotEquals(null, o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
-        Assert.assertEquals(o, null);
-        Assert.assertEquals(o, null, "Failure message to keep");
-        Assert.assertNotEquals(o, null);
-        Assert.assertNotEquals(o, null, "Failure message to keep");
+        Assert.assertNull(o);
+        Assert.assertNull(o, "Failure message to keep");
+        Assert.assertNotNull(o);
+        Assert.assertNotNull(o, "Failure message to keep");
 
-        assertEquals(o, null);
-        assertEquals(o, null, "Failure message to keep");
-        assertNotEquals(o, null);
-        assertNotEquals(o, null, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(42, o);
-        Assert.assertEquals(42, o, "Failure message to keep");
-        Assert.assertNotEquals(42, o);
-        Assert.assertNotEquals(42, o, "Failure message to keep");
+        Assert.assertEquals(o, 42);
+        Assert.assertEquals(o, 42, "Failure message to keep");
+        Assert.assertNotEquals(o, 42);
+        Assert.assertNotEquals(o, 42, "Failure message to keep");
 
-        assertEquals(42, o);
-        assertEquals(42, o, "Failure message to keep");
-        assertNotEquals(42, o);
-        assertNotEquals(42, o, "Failure message to keep");
+        org.testng.Assert.assertEquals(o, 42);
+        org.testng.Assert.assertEquals(o, 42, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o, 42);
+        org.testng.Assert.assertNotEquals(o, 42, "Failure message to keep");
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -221,15 +212,15 @@ public class TestNGAssertSample {
     }
 
     public void shouldMoveConstantAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(FOURTYTWO, o);
-        Assert.assertEquals(FOURTYTWO, o, "Failure message to keep");
-        Assert.assertNotEquals(FOURTYTWO, o);
-        Assert.assertNotEquals(FOURTYTWO, o, "Failure message to keep");
+        Assert.assertEquals(o, FOURTYTWO);
+        Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
+        Assert.assertNotEquals(o, FOURTYTWO);
+        Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
 
-        assertEquals(FOURTYTWO, o);
-        assertEquals(FOURTYTWO, o, "Failure message to keep");
-        assertNotEquals(FOURTYTWO, o);
-        assertNotEquals(FOURTYTWO, o, "Failure message to keep");
+        org.testng.Assert.assertEquals(o, FOURTYTWO);
+        org.testng.Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o, FOURTYTWO);
+        org.testng.Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -245,363 +236,155 @@ public class TestNGAssertSample {
     }
 
     public void shouldMoveExpectedVariableAsExpectedArgWithEquals(Object o, int expected) throws Exception {
-        Assert.assertEquals(expected, o);
-        Assert.assertEquals(expected, o, "Failure message to keep");
-        Assert.assertNotEquals(expected, o);
-        Assert.assertNotEquals(expected, o, "Failure message to keep");
+        Assert.assertEquals(o, expected);
+        Assert.assertEquals(o, expected, "Failure message to keep");
+        Assert.assertNotEquals(o, expected);
+        Assert.assertNotEquals(o, expected, "Failure message to keep");
 
-        assertEquals(expected, o);
-        assertEquals(expected, o, "Failure message to keep");
-        assertNotEquals(expected, o);
-        assertNotEquals(expected, o, "Failure message to keep");
+        org.testng.Assert.assertEquals(o, expected);
+        org.testng.Assert.assertEquals(o, expected, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o, expected);
+        org.testng.Assert.assertNotEquals(o, expected, "Failure message to keep");
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        assertEquals(expceted, o);
+        org.testng.Assert.assertEquals(o, expceted);
     }
 
     public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
-        if (i1 == i2) {
-            Assert.fail();
-        }
-        if (i1 == i2) {
-            Assert.fail("Failure message to keep");
-        }
-        if (i1 != i2) {
-            Assert.fail();
-        }
-        if (i1 != i2) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotEquals(i1, i2);
+        Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        Assert.assertEquals(i1, i2);
+        Assert.assertEquals(i1, i2, "Failure message to keep");
 
-        if (i1 == i2) {
-            fail();
-        }
-        if (i1 == i2) {
-            fail("Failure message to keep");
-        }
-        if (i1 != i2) {
-            fail();
-        }
-        if (i1 != i2) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotEquals(i1, i2);
+        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertEquals(i1, i2);
+        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
     }
 
     public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
-        if (o1 == o2) {
-            Assert.fail();
-        }
-        if (o1 == o2) {
-            Assert.fail("Failure message to keep");
-        }
-        if (o1 != o2) {
-            Assert.fail();
-        }
-        if (o1 != o2) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotSame(o1, o2);
+        Assert.assertNotSame(o1, o2, "Failure message to keep");
+        Assert.assertSame(o1, o2);
+        Assert.assertSame(o1, o2, "Failure message to keep");
 
-        if (o1 == o2) {
-            fail();
-        }
-        if (o1 == o2) {
-            fail("Failure message to keep");
-        }
-        if (o1 != o2) {
-            fail();
-        }
-        if (o1 != o2) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotSame(o1, o2);
+        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertSame(o1, o2);
+        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
-        if (o1 == null) {
-            Assert.fail();
-        }
-        if (o1 == null) {
-            Assert.fail("Failure message to keep");
-        }
-        if (o1 != null) {
-            Assert.fail();
-        }
-        if (o1 != null) {
-            Assert.fail("Failure message to keep");
-        }
-        if (null == o1) {
-            Assert.fail();
-        }
-        if (null == o1) {
-            Assert.fail("Failure message to keep");
-        }
-        if (null != o1) {
-            Assert.fail();
-        }
-        if (null != o1) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotNull(o1);
+        Assert.assertNotNull(o1, "Failure message to keep");
+        Assert.assertNull(o1);
+        Assert.assertNull(o1, "Failure message to keep");
+        Assert.assertNotNull(o1);
+        Assert.assertNotNull(o1, "Failure message to keep");
+        Assert.assertNull(o1);
+        Assert.assertNull(o1, "Failure message to keep");
 
-        if (o1 == null) {
-            fail();
-        }
-        if (o1 == null) {
-            fail("Failure message to keep");
-        }
-        if (o1 != null) {
-            fail();
-        }
-        if (o1 != null) {
-            fail("Failure message to keep");
-        }
-        if (null == o1) {
-            fail();
-        }
-        if (null == o1) {
-            fail("Failure message to keep");
-        }
-        if (null != o1) {
-            fail();
-        }
-        if (null != o1) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotNull(o1);
+        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNull(o1);
+        org.testng.Assert.assertNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o1);
+        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNull(o1);
+        org.testng.Assert.assertNull(o1, "Failure message to keep");
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
-        if (o1.equals(o2)) {
-            Assert.fail();
-        }
-        if (o1.equals(o2)) {
-            Assert.fail("Failure message to keep");
-        }
-        if (!o1.equals(o2)) {
-            Assert.fail();
-        }
-        if (!o1.equals(o2)) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotEquals(o1, o2);
+        Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        Assert.assertEquals(o1, o2);
+        Assert.assertEquals(o1, o2, "Failure message to keep");
 
-        if (o1.equals(o2)) {
-            fail();
-        }
-        if (o1.equals(o2)) {
-            fail("Failure message to keep");
-        }
-        if (!o1.equals(o2)) {
-            fail();
-        }
-        if (!o1.equals(o2)) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotEquals(o1, o2);
+        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertEquals(o1, o2);
+        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
-        if (i == 42) {
-            Assert.fail();
-        }
-        if (i == 42) {
-            Assert.fail("Failure message to keep");
-        }
-        if (i != 42) {
-            Assert.fail();
-        }
-        if (i != 42) {
-            Assert.fail("Failure message to keep");
-        }
-        if (42 == i) {
-            Assert.fail();
-        }
-        if (42 == i) {
-            Assert.fail("Failure message to keep");
-        }
-        if (42 != i) {
-            Assert.fail();
-        }
-        if (42 != i) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotEquals(i, 42);
+        Assert.assertNotEquals(i, 42, "Failure message to keep");
+        Assert.assertEquals(i, 42);
+        Assert.assertEquals(i, 42, "Failure message to keep");
+        Assert.assertNotEquals(i, 42);
+        Assert.assertNotEquals(i, 42, "Failure message to keep");
+        Assert.assertEquals(i, 42);
+        Assert.assertEquals(i, 42, "Failure message to keep");
 
-        if (i == 42) {
-            fail();
-        }
-        if (i == 42) {
-            fail("Failure message to keep");
-        }
-        if (i != 42) {
-            fail();
-        }
-        if (i != 42) {
-            fail("Failure message to keep");
-        }
-        if (42 == i) {
-            fail();
-        }
-        if (42 == i) {
-            fail("Failure message to keep");
-        }
-        if (42 != i) {
-            fail();
-        }
-        if (42 != i) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotEquals(i, 42);
+        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, 42);
+        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, 42);
+        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, 42);
+        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
     }
 
     public void shouldRefactorIfConstantThenFail(int i) throws Exception {
-        if (i == FOURTYTWO) {
-            Assert.fail();
-        }
-        if (i == FOURTYTWO) {
-            Assert.fail("Failure message to keep");
-        }
-        if (i != FOURTYTWO) {
-            Assert.fail();
-        }
-        if (i != FOURTYTWO) {
-            Assert.fail("Failure message to keep");
-        }
-        if (FOURTYTWO == i) {
-            Assert.fail();
-        }
-        if (FOURTYTWO == i) {
-            Assert.fail("Failure message to keep");
-        }
-        if (FOURTYTWO != i) {
-            Assert.fail();
-        }
-        if (FOURTYTWO != i) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotEquals(i, FOURTYTWO);
+        Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        Assert.assertEquals(i, FOURTYTWO);
+        Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        Assert.assertNotEquals(i, FOURTYTWO);
+        Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        Assert.assertEquals(i, FOURTYTWO);
+        Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
 
-        if (i == FOURTYTWO) {
-            fail();
-        }
-        if (i == FOURTYTWO) {
-            fail("Failure message to keep");
-        }
-        if (i != FOURTYTWO) {
-            fail();
-        }
-        if (i != FOURTYTWO) {
-            fail("Failure message to keep");
-        }
-        if (FOURTYTWO == i) {
-            fail();
-        }
-        if (FOURTYTWO == i) {
-            fail("Failure message to keep");
-        }
-        if (FOURTYTWO != i) {
-            fail();
-        }
-        if (FOURTYTWO != i) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, FOURTYTWO);
+        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, FOURTYTWO);
+        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
     }
 
     public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
-        if (i == expected) {
-            Assert.fail();
-        }
-        if (i == expected) {
-            Assert.fail("Failure message to keep");
-        }
-        if (i != expected) {
-            Assert.fail();
-        }
-        if (i != expected) {
-            Assert.fail("Failure message to keep");
-        }
-        if (expected == i) {
-            Assert.fail();
-        }
-        if (expected == i) {
-            Assert.fail("Failure message to keep");
-        }
-        if (expected != i) {
-            Assert.fail();
-        }
-        if (expected != i) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotEquals(i, expected);
+        Assert.assertNotEquals(i, expected, "Failure message to keep");
+        Assert.assertEquals(i, expected);
+        Assert.assertEquals(i, expected, "Failure message to keep");
+        Assert.assertNotEquals(i, expected);
+        Assert.assertNotEquals(i, expected, "Failure message to keep");
+        Assert.assertEquals(i, expected);
+        Assert.assertEquals(i, expected, "Failure message to keep");
 
-        if (i == expected) {
-            fail();
-        }
-        if (i == expected) {
-            fail("Failure message to keep");
-        }
-        if (i != expected) {
-            fail();
-        }
-        if (i != expected) {
-            fail("Failure message to keep");
-        }
-        if (expected == i) {
-            fail();
-        }
-        if (expected == i) {
-            fail("Failure message to keep");
-        }
-        if (expected != i) {
-            fail();
-        }
-        if (expected != i) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotEquals(i, expected);
+        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expected);
+        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, expected);
+        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expected);
+        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
     }
 
     public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
-        if (i == expectedI) {
-            Assert.fail();
-        }
-        if (i == expectedI) {
-            Assert.fail("Failure message to keep");
-        }
-        if (i != expectedI) {
-            Assert.fail();
-        }
-        if (i != expectedI) {
-            Assert.fail("Failure message to keep");
-        }
-        if (expectedI == i) {
-            Assert.fail();
-        }
-        if (expectedI == i) {
-            Assert.fail("Failure message to keep");
-        }
-        if (expectedI != i) {
-            Assert.fail();
-        }
-        if (expectedI != i) {
-            Assert.fail("Failure message to keep");
-        }
+        Assert.assertNotEquals(i, expectedI);
+        Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        Assert.assertEquals(i, expectedI);
+        Assert.assertEquals(i, expectedI, "Failure message to keep");
+        Assert.assertNotEquals(i, expectedI);
+        Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        Assert.assertEquals(i, expectedI);
+        Assert.assertEquals(i, expectedI, "Failure message to keep");
 
-        if (i == expectedI) {
-            fail();
-        }
-        if (i == expectedI) {
-            fail("Failure message to keep");
-        }
-        if (i != expectedI) {
-            fail();
-        }
-        if (i != expectedI) {
-            fail("Failure message to keep");
-        }
-        if (expectedI == i) {
-            fail();
-        }
-        if (expectedI == i) {
-            fail("Failure message to keep");
-        }
-        if (expectedI != i) {
-            fail();
-        }
-        if (expectedI != i) {
-            fail("Failure message to keep");
-        }
+        org.testng.Assert.assertNotEquals(i, expectedI);
+        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expectedI);
+        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, expectedI);
+        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expectedI);
+        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/TestNGAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/TestNGAssertSample.java
@@ -37,166 +37,175 @@ public class TestNGAssertSample {
     private static final int FOURTYTWO = 42;
 
     public void shouldRefactorWithPrimitives(int i1, int i2) throws Exception {
-        Assert.assertEquals(i1, i2);
-        Assert.assertEquals(i1, i2, "Failure message to keep");
-        Assert.assertNotEquals(i1, i2);
-        Assert.assertNotEquals(i1, i2, "Failure message to keep");
-        Assert.assertEquals(i1, i2);
-        Assert.assertEquals(i1, i2, "Failure message to keep");
-        Assert.assertNotEquals(i1, i2);
-        Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        Assert.assertTrue(i1 == i2);
+        Assert.assertTrue(i1 == i2, "Failure message to keep");
+        Assert.assertTrue(i1 != i2);
+        Assert.assertTrue(i1 != i2, "Failure message to keep");
+        Assert.assertFalse(i1 != i2);
+        Assert.assertFalse(i1 != i2, "Failure message to keep");
+        Assert.assertFalse(i1 == i2);
+        Assert.assertFalse(i1 == i2, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(i1, i2);
-        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i1, i2);
-        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertEquals(i1, i2);
-        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i1, i2);
-        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        assertTrue(i1 == i2);
+        assertTrue(i1 == i2, "Failure message to keep");
+        assertTrue(i1 != i2);
+        assertTrue(i1 != i2, "Failure message to keep");
+        assertFalse(i1 != i2);
+        assertFalse(i1 != i2, "Failure message to keep");
+        assertFalse(i1 == i2);
+        assertFalse(i1 == i2, "Failure message to keep");
     }
 
     public void shouldRefactorFailures() throws Exception {
-        Assert.fail();
-        Assert.fail("Failure message to keep");
-        Assert.fail();
-        Assert.fail("Failure message to keep");
+        Assert.assertTrue(false);
+        Assert.assertTrue(false, "Failure message to keep");
+        Assert.assertFalse(true);
+        Assert.assertFalse(true, "Failure message to keep");
 
-        org.testng.Assert.fail();
-        org.testng.Assert.fail("Failure message to keep");
-        org.testng.Assert.fail();
-        org.testng.Assert.fail("Failure message to keep");
+        assertTrue(false);
+        assertTrue(false, "Failure message to keep");
+        assertFalse(true);
+        assertFalse(true, "Failure message to keep");
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
+        Assert.assertTrue(true);
+        Assert.assertTrue(true, "Failure message to keep");
+        Assert.assertFalse(false);
+        Assert.assertFalse(false, "Failure message to keep");
+
+        assertTrue(true);
+        assertTrue(true, "Failure message to keep");
+        assertFalse(false);
+        assertFalse(false, "Failure message to keep");
     }
 
     public void shouldRefactorNegatedConditions(boolean b) throws Exception {
-        Assert.assertFalse(b);
-        Assert.assertFalse(b, "Failure message to keep");
-        Assert.assertTrue(b);
-        Assert.assertTrue(b, "Failure message to keep");
+        Assert.assertTrue(!b);
+        Assert.assertTrue(!b, "Failure message to keep");
+        Assert.assertFalse(!b);
+        Assert.assertFalse(!b, "Failure message to keep");
 
-        org.testng.Assert.assertFalse(b);
-        org.testng.Assert.assertFalse(b, "Failure message to keep");
-        org.testng.Assert.assertTrue(b);
-        org.testng.Assert.assertTrue(b, "Failure message to keep");
+        assertTrue(!b);
+        assertTrue(!b, "Failure message to keep");
+        assertFalse(!b);
+        assertFalse(!b, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
-        Assert.assertSame(o1, o2);
-        Assert.assertSame(o1, o2, "Failure message to keep");
-        Assert.assertNotSame(o1, o2);
-        Assert.assertNotSame(o1, o2, "Failure message to keep");
-        Assert.assertSame(o1, o2);
-        Assert.assertSame(o1, o2, "Failure message to keep");
-        Assert.assertNotSame(o1, o2);
-        Assert.assertNotSame(o1, o2, "Failure message to keep");
+        Assert.assertTrue(o1 == o2);
+        Assert.assertTrue(o1 == o2, "Failure message to keep");
+        Assert.assertTrue(o1 != o2);
+        Assert.assertTrue(o1 != o2, "Failure message to keep");
+        Assert.assertFalse(o1 != o2);
+        Assert.assertFalse(o1 != o2, "Failure message to keep");
+        Assert.assertFalse(o1 == o2);
+        Assert.assertFalse(o1 == o2, "Failure message to keep");
 
-        org.testng.Assert.assertSame(o1, o2);
-        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotSame(o1, o2);
-        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertSame(o1, o2);
-        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotSame(o1, o2);
-        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
+        assertTrue(o1 == o2);
+        assertTrue(o1 == o2, "Failure message to keep");
+        assertTrue(o1 != o2);
+        assertTrue(o1 != o2, "Failure message to keep");
+        assertFalse(o1 != o2);
+        assertFalse(o1 != o2, "Failure message to keep");
+        assertFalse(o1 == o2);
+        assertFalse(o1 == o2, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
-        Assert.assertEquals(o1, o2);
-        Assert.assertEquals(o1, o2, "Failure message to keep");
-        Assert.assertNotEquals(o1, o2);
-        Assert.assertNotEquals(o1, o2, "Failure message to keep");
-        Assert.assertEquals(o1, o2);
-        Assert.assertEquals(o1, o2, "Failure message to keep");
-        Assert.assertNotEquals(o1, o2);
-        Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        Assert.assertTrue(o1.equals(o2));
+        Assert.assertTrue(o1.equals(o2), "Failure message to keep");
+        Assert.assertTrue(!(o1.equals(o2)));
+        Assert.assertTrue(!(o1.equals(o2)), "Failure message to keep");
+        Assert.assertFalse(!(o1.equals(o2)));
+        Assert.assertFalse(!(o1.equals(o2)), "Failure message to keep");
+        Assert.assertFalse(o1.equals(o2));
+        Assert.assertFalse(o1.equals(o2), "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o1, o2);
-        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o1, o2);
-        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertEquals(o1, o2);
-        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o1, o2);
-        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        assertTrue(o1.equals(o2));
+        assertTrue(o1.equals(o2), "Failure message to keep");
+        assertTrue(!(o1.equals(o2)));
+        assertTrue(!(o1.equals(o2)), "Failure message to keep");
+        assertFalse(!(o1.equals(o2)));
+        assertFalse(!(o1.equals(o2)), "Failure message to keep");
+        assertFalse(o1.equals(o2));
+        assertFalse(o1.equals(o2), "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
-        Assert.assertNull(o);
-        Assert.assertNull(o, "Failure message to keep");
-        Assert.assertNotNull(o);
-        Assert.assertNotNull(o, "Failure message to keep");
-        Assert.assertNull(o);
-        Assert.assertNull(o, "Failure message to keep");
-        Assert.assertNotNull(o);
-        Assert.assertNotNull(o, "Failure message to keep");
+        Assert.assertTrue(null == o);
+        Assert.assertTrue(null == o, "Failure message to keep");
+        Assert.assertTrue(null != o);
+        Assert.assertTrue(null != o, "Failure message to keep");
+        Assert.assertFalse(null != o);
+        Assert.assertFalse(null != o, "Failure message to keep");
+        Assert.assertFalse(null == o);
+        Assert.assertFalse(null == o, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertTrue(null == o);
+        assertTrue(null == o, "Failure message to keep");
+        assertTrue(null != o);
+        assertTrue(null != o, "Failure message to keep");
+        assertFalse(null != o);
+        assertFalse(null != o, "Failure message to keep");
+        assertFalse(null == o);
+        assertFalse(null == o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
-        Assert.assertNull(o);
-        Assert.assertNull(o, "Failure message to keep");
-        Assert.assertNotNull(o);
-        Assert.assertNotNull(o, "Failure message to keep");
-        Assert.assertNull(o);
-        Assert.assertNull(o, "Failure message to keep");
-        Assert.assertNotNull(o);
-        Assert.assertNotNull(o, "Failure message to keep");
+        Assert.assertTrue(o == null);
+        Assert.assertTrue(o == null, "Failure message to keep");
+        Assert.assertTrue(o != null);
+        Assert.assertTrue(o != null, "Failure message to keep");
+        Assert.assertFalse(o != null);
+        Assert.assertFalse(o != null, "Failure message to keep");
+        Assert.assertFalse(o == null);
+        Assert.assertFalse(o == null, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertTrue(o == null);
+        assertTrue(o == null, "Failure message to keep");
+        assertTrue(o != null);
+        assertTrue(o != null, "Failure message to keep");
+        assertFalse(o != null);
+        assertFalse(o != null, "Failure message to keep");
+        assertFalse(o == null);
+        assertFalse(o == null, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
-        Assert.assertNull(o);
-        Assert.assertNull(o, "Failure message to keep");
-        Assert.assertNotNull(o);
-        Assert.assertNotNull(o, "Failure message to keep");
+        Assert.assertEquals(null, o);
+        Assert.assertEquals(null, o, "Failure message to keep");
+        Assert.assertNotEquals(null, o);
+        Assert.assertNotEquals(null, o, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertEquals(null, o);
+        assertEquals(null, o, "Failure message to keep");
+        assertNotEquals(null, o);
+        assertNotEquals(null, o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
-        Assert.assertNull(o);
-        Assert.assertNull(o, "Failure message to keep");
-        Assert.assertNotNull(o);
-        Assert.assertNotNull(o, "Failure message to keep");
+        Assert.assertEquals(o, null);
+        Assert.assertEquals(o, null, "Failure message to keep");
+        Assert.assertNotEquals(o, null);
+        Assert.assertNotEquals(o, null, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertEquals(o, null);
+        assertEquals(o, null, "Failure message to keep");
+        assertNotEquals(o, null);
+        assertNotEquals(o, null, "Failure message to keep");
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(o, 42);
-        Assert.assertEquals(o, 42, "Failure message to keep");
-        Assert.assertNotEquals(o, 42);
-        Assert.assertNotEquals(o, 42, "Failure message to keep");
+        Assert.assertEquals(42, o);
+        Assert.assertEquals(42, o, "Failure message to keep");
+        Assert.assertNotEquals(42, o);
+        Assert.assertNotEquals(42, o, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o, 42);
-        org.testng.Assert.assertEquals(o, 42, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o, 42);
-        org.testng.Assert.assertNotEquals(o, 42, "Failure message to keep");
+        assertEquals(42, o);
+        assertEquals(42, o, "Failure message to keep");
+        assertNotEquals(42, o);
+        assertNotEquals(42, o, "Failure message to keep");
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -212,15 +221,15 @@ public class TestNGAssertSample {
     }
 
     public void shouldMoveConstantAsExpectedArgInWithEquals(Object o) throws Exception {
-        Assert.assertEquals(o, FOURTYTWO);
-        Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
-        Assert.assertNotEquals(o, FOURTYTWO);
-        Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+        Assert.assertEquals(FOURTYTWO, o);
+        Assert.assertEquals(FOURTYTWO, o, "Failure message to keep");
+        Assert.assertNotEquals(FOURTYTWO, o);
+        Assert.assertNotEquals(FOURTYTWO, o, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o, FOURTYTWO);
-        org.testng.Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o, FOURTYTWO);
-        org.testng.Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+        assertEquals(FOURTYTWO, o);
+        assertEquals(FOURTYTWO, o, "Failure message to keep");
+        assertNotEquals(FOURTYTWO, o);
+        assertNotEquals(FOURTYTWO, o, "Failure message to keep");
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -236,155 +245,363 @@ public class TestNGAssertSample {
     }
 
     public void shouldMoveExpectedVariableAsExpectedArgWithEquals(Object o, int expected) throws Exception {
-        Assert.assertEquals(o, expected);
-        Assert.assertEquals(o, expected, "Failure message to keep");
-        Assert.assertNotEquals(o, expected);
-        Assert.assertNotEquals(o, expected, "Failure message to keep");
+        Assert.assertEquals(expected, o);
+        Assert.assertEquals(expected, o, "Failure message to keep");
+        Assert.assertNotEquals(expected, o);
+        Assert.assertNotEquals(expected, o, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o, expected);
-        org.testng.Assert.assertEquals(o, expected, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o, expected);
-        org.testng.Assert.assertNotEquals(o, expected, "Failure message to keep");
+        assertEquals(expected, o);
+        assertEquals(expected, o, "Failure message to keep");
+        assertNotEquals(expected, o);
+        assertNotEquals(expected, o, "Failure message to keep");
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        org.testng.Assert.assertEquals(o, expceted);
+        assertEquals(expceted, o);
     }
 
     public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
-        Assert.assertNotEquals(i1, i2);
-        Assert.assertNotEquals(i1, i2, "Failure message to keep");
-        Assert.assertEquals(i1, i2);
-        Assert.assertEquals(i1, i2, "Failure message to keep");
+        if (i1 == i2) {
+            Assert.fail();
+        }
+        if (i1 == i2) {
+            Assert.fail("Failure message to keep");
+        }
+        if (i1 != i2) {
+            Assert.fail();
+        }
+        if (i1 != i2) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotEquals(i1, i2);
-        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertEquals(i1, i2);
-        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
+        if (i1 == i2) {
+            fail();
+        }
+        if (i1 == i2) {
+            fail("Failure message to keep");
+        }
+        if (i1 != i2) {
+            fail();
+        }
+        if (i1 != i2) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
-        Assert.assertNotSame(o1, o2);
-        Assert.assertNotSame(o1, o2, "Failure message to keep");
-        Assert.assertSame(o1, o2);
-        Assert.assertSame(o1, o2, "Failure message to keep");
+        if (o1 == o2) {
+            Assert.fail();
+        }
+        if (o1 == o2) {
+            Assert.fail("Failure message to keep");
+        }
+        if (o1 != o2) {
+            Assert.fail();
+        }
+        if (o1 != o2) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotSame(o1, o2);
-        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertSame(o1, o2);
-        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
+        if (o1 == o2) {
+            fail();
+        }
+        if (o1 == o2) {
+            fail("Failure message to keep");
+        }
+        if (o1 != o2) {
+            fail();
+        }
+        if (o1 != o2) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
-        Assert.assertNotNull(o1);
-        Assert.assertNotNull(o1, "Failure message to keep");
-        Assert.assertNull(o1);
-        Assert.assertNull(o1, "Failure message to keep");
-        Assert.assertNotNull(o1);
-        Assert.assertNotNull(o1, "Failure message to keep");
-        Assert.assertNull(o1);
-        Assert.assertNull(o1, "Failure message to keep");
+        if (o1 == null) {
+            Assert.fail();
+        }
+        if (o1 == null) {
+            Assert.fail("Failure message to keep");
+        }
+        if (o1 != null) {
+            Assert.fail();
+        }
+        if (o1 != null) {
+            Assert.fail("Failure message to keep");
+        }
+        if (null == o1) {
+            Assert.fail();
+        }
+        if (null == o1) {
+            Assert.fail("Failure message to keep");
+        }
+        if (null != o1) {
+            Assert.fail();
+        }
+        if (null != o1) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotNull(o1);
-        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
-        org.testng.Assert.assertNull(o1);
-        org.testng.Assert.assertNull(o1, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o1);
-        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
-        org.testng.Assert.assertNull(o1);
-        org.testng.Assert.assertNull(o1, "Failure message to keep");
+        if (o1 == null) {
+            fail();
+        }
+        if (o1 == null) {
+            fail("Failure message to keep");
+        }
+        if (o1 != null) {
+            fail();
+        }
+        if (o1 != null) {
+            fail("Failure message to keep");
+        }
+        if (null == o1) {
+            fail();
+        }
+        if (null == o1) {
+            fail("Failure message to keep");
+        }
+        if (null != o1) {
+            fail();
+        }
+        if (null != o1) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
-        Assert.assertNotEquals(o1, o2);
-        Assert.assertNotEquals(o1, o2, "Failure message to keep");
-        Assert.assertEquals(o1, o2);
-        Assert.assertEquals(o1, o2, "Failure message to keep");
+        if (o1.equals(o2)) {
+            Assert.fail();
+        }
+        if (o1.equals(o2)) {
+            Assert.fail("Failure message to keep");
+        }
+        if (!o1.equals(o2)) {
+            Assert.fail();
+        }
+        if (!o1.equals(o2)) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotEquals(o1, o2);
-        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertEquals(o1, o2);
-        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
+        if (o1.equals(o2)) {
+            fail();
+        }
+        if (o1.equals(o2)) {
+            fail("Failure message to keep");
+        }
+        if (!o1.equals(o2)) {
+            fail();
+        }
+        if (!o1.equals(o2)) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
-        Assert.assertNotEquals(i, 42);
-        Assert.assertNotEquals(i, 42, "Failure message to keep");
-        Assert.assertEquals(i, 42);
-        Assert.assertEquals(i, 42, "Failure message to keep");
-        Assert.assertNotEquals(i, 42);
-        Assert.assertNotEquals(i, 42, "Failure message to keep");
-        Assert.assertEquals(i, 42);
-        Assert.assertEquals(i, 42, "Failure message to keep");
+        if (i == 42) {
+            Assert.fail();
+        }
+        if (i == 42) {
+            Assert.fail("Failure message to keep");
+        }
+        if (i != 42) {
+            Assert.fail();
+        }
+        if (i != 42) {
+            Assert.fail("Failure message to keep");
+        }
+        if (42 == i) {
+            Assert.fail();
+        }
+        if (42 == i) {
+            Assert.fail("Failure message to keep");
+        }
+        if (42 != i) {
+            Assert.fail();
+        }
+        if (42 != i) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotEquals(i, 42);
-        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, 42);
-        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, 42);
-        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, 42);
-        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
+        if (i == 42) {
+            fail();
+        }
+        if (i == 42) {
+            fail("Failure message to keep");
+        }
+        if (i != 42) {
+            fail();
+        }
+        if (i != 42) {
+            fail("Failure message to keep");
+        }
+        if (42 == i) {
+            fail();
+        }
+        if (42 == i) {
+            fail("Failure message to keep");
+        }
+        if (42 != i) {
+            fail();
+        }
+        if (42 != i) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfConstantThenFail(int i) throws Exception {
-        Assert.assertNotEquals(i, FOURTYTWO);
-        Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        Assert.assertEquals(i, FOURTYTWO);
-        Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
-        Assert.assertNotEquals(i, FOURTYTWO);
-        Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        Assert.assertEquals(i, FOURTYTWO);
-        Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        if (i == FOURTYTWO) {
+            Assert.fail();
+        }
+        if (i == FOURTYTWO) {
+            Assert.fail("Failure message to keep");
+        }
+        if (i != FOURTYTWO) {
+            Assert.fail();
+        }
+        if (i != FOURTYTWO) {
+            Assert.fail("Failure message to keep");
+        }
+        if (FOURTYTWO == i) {
+            Assert.fail();
+        }
+        if (FOURTYTWO == i) {
+            Assert.fail("Failure message to keep");
+        }
+        if (FOURTYTWO != i) {
+            Assert.fail();
+        }
+        if (FOURTYTWO != i) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, FOURTYTWO);
-        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, FOURTYTWO);
-        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        if (i == FOURTYTWO) {
+            fail();
+        }
+        if (i == FOURTYTWO) {
+            fail("Failure message to keep");
+        }
+        if (i != FOURTYTWO) {
+            fail();
+        }
+        if (i != FOURTYTWO) {
+            fail("Failure message to keep");
+        }
+        if (FOURTYTWO == i) {
+            fail();
+        }
+        if (FOURTYTWO == i) {
+            fail("Failure message to keep");
+        }
+        if (FOURTYTWO != i) {
+            fail();
+        }
+        if (FOURTYTWO != i) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
-        Assert.assertNotEquals(i, expected);
-        Assert.assertNotEquals(i, expected, "Failure message to keep");
-        Assert.assertEquals(i, expected);
-        Assert.assertEquals(i, expected, "Failure message to keep");
-        Assert.assertNotEquals(i, expected);
-        Assert.assertNotEquals(i, expected, "Failure message to keep");
-        Assert.assertEquals(i, expected);
-        Assert.assertEquals(i, expected, "Failure message to keep");
+        if (i == expected) {
+            Assert.fail();
+        }
+        if (i == expected) {
+            Assert.fail("Failure message to keep");
+        }
+        if (i != expected) {
+            Assert.fail();
+        }
+        if (i != expected) {
+            Assert.fail("Failure message to keep");
+        }
+        if (expected == i) {
+            Assert.fail();
+        }
+        if (expected == i) {
+            Assert.fail("Failure message to keep");
+        }
+        if (expected != i) {
+            Assert.fail();
+        }
+        if (expected != i) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotEquals(i, expected);
-        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expected);
-        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, expected);
-        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expected);
-        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
+        if (i == expected) {
+            fail();
+        }
+        if (i == expected) {
+            fail("Failure message to keep");
+        }
+        if (i != expected) {
+            fail();
+        }
+        if (i != expected) {
+            fail("Failure message to keep");
+        }
+        if (expected == i) {
+            fail();
+        }
+        if (expected == i) {
+            fail("Failure message to keep");
+        }
+        if (expected != i) {
+            fail();
+        }
+        if (expected != i) {
+            fail("Failure message to keep");
+        }
     }
 
     public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
-        Assert.assertNotEquals(i, expectedI);
-        Assert.assertNotEquals(i, expectedI, "Failure message to keep");
-        Assert.assertEquals(i, expectedI);
-        Assert.assertEquals(i, expectedI, "Failure message to keep");
-        Assert.assertNotEquals(i, expectedI);
-        Assert.assertNotEquals(i, expectedI, "Failure message to keep");
-        Assert.assertEquals(i, expectedI);
-        Assert.assertEquals(i, expectedI, "Failure message to keep");
+        if (i == expectedI) {
+            Assert.fail();
+        }
+        if (i == expectedI) {
+            Assert.fail("Failure message to keep");
+        }
+        if (i != expectedI) {
+            Assert.fail();
+        }
+        if (i != expectedI) {
+            Assert.fail("Failure message to keep");
+        }
+        if (expectedI == i) {
+            Assert.fail();
+        }
+        if (expectedI == i) {
+            Assert.fail("Failure message to keep");
+        }
+        if (expectedI != i) {
+            Assert.fail();
+        }
+        if (expectedI != i) {
+            Assert.fail("Failure message to keep");
+        }
 
-        org.testng.Assert.assertNotEquals(i, expectedI);
-        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expectedI);
-        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, expectedI);
-        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expectedI);
-        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
+        if (i == expectedI) {
+            fail();
+        }
+        if (i == expectedI) {
+            fail("Failure message to keep");
+        }
+        if (i != expectedI) {
+            fail();
+        }
+        if (i != expectedI) {
+            fail("Failure message to keep");
+        }
+        if (expectedI == i) {
+            fail();
+        }
+        if (expectedI == i) {
+            fail("Failure message to keep");
+        }
+        if (expectedI != i) {
+            fail();
+        }
+        if (expectedI != i) {
+            fail("Failure message to keep");
+        }
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/JUnitAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/JUnitAssertSample.java
@@ -1,0 +1,401 @@
+/*
+ * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
+ *
+ * Copyright (C) 2016 Fabrice Tiercelin - initial API and implementation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program under LICENSE-GNUGPL.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution under LICENSE-ECLIPSE, and is
+ * available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.autorefactor.refactoring.rules.samples_out;
+
+import static org.junit.Assert.*;
+
+import org.junit.Assert;
+
+public class JUnitAssertSample {
+
+    private static final int FOURTYTWO = 42;
+
+    public void shouldRefactorWithPrimitives(int i1, int i2) throws Exception {
+        Assert.assertEquals(i1, i2);
+        Assert.assertEquals("Failure message to keep", i1, i2);
+        Assert.assertEquals(i1, i2);
+        Assert.assertEquals("Failure message to keep", i1, i2);
+
+        assertEquals(i1, i2);
+        assertEquals("Failure message to keep", i1, i2);
+        assertEquals(i1, i2);
+        assertEquals("Failure message to keep", i1, i2);
+    }
+
+    public void shouldRefactorFailures() throws Exception {
+        Assert.fail();
+        Assert.fail("Failure message to keep");
+        Assert.fail();
+        Assert.fail("Failure message to keep");
+
+        fail();
+        fail("Failure message to keep");
+        fail();
+        fail("Failure message to keep");
+    }
+
+    public void shouldRemoveDeadChecks() throws Exception {
+    }
+
+    public void shouldRefactorNegatedConditions(boolean b) throws Exception {
+        Assert.assertFalse(b);
+        Assert.assertFalse("Failure message to keep", b);
+        Assert.assertTrue(b);
+        Assert.assertTrue("Failure message to keep", b);
+
+        assertFalse(b);
+        assertFalse("Failure message to keep", b);
+        assertTrue(b);
+        assertTrue("Failure message to keep", b);
+    }
+
+    public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
+        Assert.assertSame(o1, o2);
+        Assert.assertSame("Failure message to keep", o1, o2);
+        Assert.assertNotSame(o1, o2);
+        Assert.assertNotSame("Failure message to keep", o1, o2);
+        Assert.assertSame(o1, o2);
+        Assert.assertSame("Failure message to keep", o1, o2);
+        Assert.assertNotSame(o1, o2);
+        Assert.assertNotSame("Failure message to keep", o1, o2);
+
+        assertSame(o1, o2);
+        assertSame("Failure message to keep", o1, o2);
+        assertNotSame(o1, o2);
+        assertNotSame("Failure message to keep", o1, o2);
+        assertSame(o1, o2);
+        assertSame("Failure message to keep", o1, o2);
+        assertNotSame(o1, o2);
+        assertNotSame("Failure message to keep", o1, o2);
+    }
+
+    public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
+        Assert.assertEquals(o1, o2);
+        Assert.assertEquals("Failure message to keep", o1, o2);
+        Assert.assertEquals(o1, o2);
+        Assert.assertEquals("Failure message to keep", o1, o2);
+
+        assertEquals(o1, o2);
+        assertEquals("Failure message to keep", o1, o2);
+        assertEquals(o1, o2);
+        assertEquals("Failure message to keep", o1, o2);
+    }
+
+    public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
+        Assert.assertNull(o);
+        Assert.assertNull("Failure message to keep", o);
+        Assert.assertNotNull(o);
+        Assert.assertNotNull("Failure message to keep", o);
+        Assert.assertNull(o);
+        Assert.assertNull("Failure message to keep", o);
+        Assert.assertNotNull(o);
+        Assert.assertNotNull("Failure message to keep", o);
+
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
+    }
+
+    public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
+        Assert.assertNull(o);
+        Assert.assertNull("Failure message to keep", o);
+        Assert.assertNotNull(o);
+        Assert.assertNotNull("Failure message to keep", o);
+        Assert.assertNull(o);
+        Assert.assertNull("Failure message to keep", o);
+        Assert.assertNotNull(o);
+        Assert.assertNotNull("Failure message to keep", o);
+
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
+    }
+
+    public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
+        Assert.assertNull(o);
+        Assert.assertNull("Failure message to keep", o);
+
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+    }
+
+    public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
+        Assert.assertNull(o);
+        Assert.assertNull("Failure message to keep", o);
+
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+    }
+
+    public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(42, o);
+        Assert.assertEquals("Failure message to keep", 42, o);
+
+        assertEquals(42, o);
+        assertEquals("Failure message to keep", 42, o);
+    }
+
+    public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(42, o);
+        Assert.assertEquals("Failure message to keep", 42, o);
+
+        assertEquals(42, o);
+        assertEquals("Failure message to keep", 42, o);
+    }
+
+    public void shouldMoveConstantAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(FOURTYTWO, o);
+        Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
+
+        assertEquals(FOURTYTWO, o);
+        assertEquals("Failure message to keep", FOURTYTWO, o);
+    }
+
+    public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(FOURTYTWO, o);
+        Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
+
+        assertEquals(FOURTYTWO, o);
+        assertEquals("Failure message to keep", FOURTYTWO, o);
+    }
+
+    public void shouldMoveExpectedObjectAsExpectedArgWithEquals(Object o, int expected) throws Exception {
+        Assert.assertEquals(expected, o);
+        Assert.assertEquals("Failure message to keep", expected, o);
+
+        assertEquals(expected, o);
+        assertEquals("Failure message to keep", expected, o);
+
+        // tests that this works according to levenshtein distance
+        int expceted = 0;
+        assertEquals(expceted, o);
+    }
+
+    public void doNotRefactorExpectedObjectAsExpectedArgWithEquals(Object o, int expected) throws Exception {
+        Assert.assertEquals(expected, o);
+        Assert.assertEquals("Failure message to keep", expected, o);
+
+        assertEquals(expected, o);
+        assertEquals("Failure message to keep", expected, o);
+
+        int expceted = 0;
+        assertEquals(expceted, o);
+    }
+
+    public void shouldMoveExpectedLongAsExpectedArgWithEquals(long l, long expected) throws Exception {
+        Assert.assertEquals(expected, l);
+        Assert.assertEquals("Failure message to keep", expected, l);
+
+        assertEquals(expected, l);
+        assertEquals("Failure message to keep", expected, l);
+
+        // tests that this works according to levenshtein distance
+        int expceted = 0;
+        assertEquals(expceted, l);
+    }
+
+    public void shouldMoveExpectedDoubleAsExpectedArgWithEquals(double d, double expected) throws Exception {
+        Assert.assertEquals(expected, d);
+        Assert.assertEquals("Failure message to keep", expected, d);
+
+        assertEquals(expected, d);
+        assertEquals("Failure message to keep", expected, d);
+
+        // tests that this works according to levenshtein distance
+        int expceted = 0;
+        assertEquals(expceted, d);
+    }
+
+    public void shouldRefactorIfOnBoolean(boolean b) throws Exception {
+        Assert.assertFalse(b);
+        Assert.assertFalse("Failure message to keep", b);
+
+        assertTrue(b);
+        assertTrue("Failure message to keep", b);
+    }
+
+    public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
+        Assert.assertEquals(i1, i2);
+        Assert.assertEquals("Failure message to keep", i1, i2);
+
+        assertEquals(i1, i2);
+        assertEquals("Failure message to keep", i1, i2);
+    }
+
+    public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
+        Assert.assertNotSame(o1, o2);
+        Assert.assertNotSame("Failure message to keep", o1, o2);
+        Assert.assertSame(o1, o2);
+        Assert.assertSame("Failure message to keep", o1, o2);
+
+        assertNotSame(o1, o2);
+        assertNotSame("Failure message to keep", o1, o2);
+        assertSame(o1, o2);
+        assertSame("Failure message to keep", o1, o2);
+    }
+
+    public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
+        Assert.assertNotNull(o1);
+        Assert.assertNotNull("Failure message to keep", o1);
+        Assert.assertNull(o1);
+        Assert.assertNull("Failure message to keep", o1);
+        Assert.assertNotNull(o1);
+        Assert.assertNotNull("Failure message to keep", o1);
+        Assert.assertNull(o1);
+        Assert.assertNull("Failure message to keep", o1);
+
+        assertNotNull(o1);
+        assertNotNull("Failure message to keep", o1);
+        assertNull(o1);
+        assertNull("Failure message to keep", o1);
+        assertNotNull(o1);
+        assertNotNull("Failure message to keep", o1);
+        assertNull(o1);
+        assertNull("Failure message to keep", o1);
+    }
+
+    public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
+        Assert.assertEquals(o1, o2);
+        Assert.assertEquals("Failure message to keep", o1, o2);
+
+        assertEquals(o1, o2);
+        assertEquals("Failure message to keep", o1, o2);
+    }
+
+    public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
+        Assert.assertNotEquals(42, i);
+        Assert.assertNotEquals("Failure message to keep", 42, i);
+        Assert.assertEquals(42, i);
+        Assert.assertEquals("Failure message to keep", 42, i);
+        Assert.assertNotEquals(42, i);
+        Assert.assertNotEquals("Failure message to keep", 42, i);
+        Assert.assertEquals(42, i);
+        Assert.assertEquals("Failure message to keep", 42, i);
+
+        assertNotEquals(42, i);
+        assertNotEquals("Failure message to keep", 42, i);
+        assertEquals(42, i);
+        assertEquals("Failure message to keep", 42, i);
+        assertNotEquals(42, i);
+        assertNotEquals("Failure message to keep", 42, i);
+        assertEquals(42, i);
+        assertEquals("Failure message to keep", 42, i);
+    }
+
+    public void shouldRefactorIfConstantThenFail(int i) throws Exception {
+        Assert.assertNotEquals(FOURTYTWO, i);
+        Assert.assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        Assert.assertEquals(FOURTYTWO, i);
+        Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
+        Assert.assertNotEquals(FOURTYTWO, i);
+        Assert.assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        Assert.assertEquals(FOURTYTWO, i);
+        Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
+
+        assertNotEquals(FOURTYTWO, i);
+        assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        assertEquals(FOURTYTWO, i);
+        assertEquals("Failure message to keep", FOURTYTWO, i);
+        assertNotEquals(FOURTYTWO, i);
+        assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        assertEquals(FOURTYTWO, i);
+        assertEquals("Failure message to keep", FOURTYTWO, i);
+    }
+
+    public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
+        Assert.assertNotEquals(expected, i);
+        Assert.assertNotEquals("Failure message to keep", expected, i);
+        Assert.assertEquals(expected, i);
+        Assert.assertEquals("Failure message to keep", expected, i);
+        Assert.assertNotEquals(expected, i);
+        Assert.assertNotEquals("Failure message to keep", expected, i);
+        Assert.assertEquals(expected, i);
+        Assert.assertEquals("Failure message to keep", expected, i);
+
+        assertNotEquals(expected, i);
+        assertNotEquals("Failure message to keep", expected, i);
+        assertEquals(expected, i);
+        assertEquals("Failure message to keep", expected, i);
+        assertNotEquals(expected, i);
+        assertNotEquals("Failure message to keep", expected, i);
+        assertEquals(expected, i);
+        assertEquals("Failure message to keep", expected, i);
+    }
+
+    public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
+        Assert.assertNotEquals(expectedI, i);
+        Assert.assertNotEquals("Failure message to keep", expectedI, i);
+        Assert.assertEquals(expectedI, i);
+        Assert.assertEquals("Failure message to keep", expectedI, i);
+        Assert.assertNotEquals(expectedI, i);
+        Assert.assertNotEquals("Failure message to keep", expectedI, i);
+        Assert.assertEquals(expectedI, i);
+        Assert.assertEquals("Failure message to keep", expectedI, i);
+
+        assertNotEquals(expectedI, i);
+        assertNotEquals("Failure message to keep", expectedI, i);
+        assertEquals(expectedI, i);
+        assertEquals("Failure message to keep", expectedI, i);
+        assertNotEquals(expectedI, i);
+        assertNotEquals("Failure message to keep", expectedI, i);
+        assertEquals(expectedI, i);
+        assertEquals("Failure message to keep", expectedI, i);
+    }
+
+    public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {
+        if (i1 == i2) {
+            Assert.fail();
+        } else {
+            System.out.println("keep me!");
+        }
+        if (o1 == null) {
+            Assert.fail();
+        } else {
+            System.out.println("keep me!");
+        }
+        Object o2 = i2;
+        if (o1 == o2) {
+            Assert.fail();
+        } else {
+            System.out.println("keep me!");
+        }
+        if (o1.equals(o2)) {
+            Assert.fail();
+        } else {
+            System.out.println("keep me!");
+        }
+    }
+}

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/JUnitAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/JUnitAssertSample.java
@@ -39,10 +39,10 @@ public class JUnitAssertSample {
         Assert.assertEquals(i1, i2);
         Assert.assertEquals("Failure message to keep", i1, i2);
 
-        org.junit.Assert.assertEquals(i1, i2);
-        org.junit.Assert.assertEquals("Failure message to keep", i1, i2);
-        org.junit.Assert.assertEquals(i1, i2);
-        org.junit.Assert.assertEquals("Failure message to keep", i1, i2);
+        assertEquals(i1, i2);
+        assertEquals("Failure message to keep", i1, i2);
+        assertEquals(i1, i2);
+        assertEquals("Failure message to keep", i1, i2);
     }
 
     public void shouldRefactorFailures() throws Exception {
@@ -51,10 +51,10 @@ public class JUnitAssertSample {
         Assert.fail();
         Assert.fail("Failure message to keep");
 
-        org.junit.Assert.fail();
-        org.junit.Assert.fail("Failure message to keep");
-        org.junit.Assert.fail();
-        org.junit.Assert.fail("Failure message to keep");
+        fail();
+        fail("Failure message to keep");
+        fail();
+        fail("Failure message to keep");
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
@@ -66,10 +66,10 @@ public class JUnitAssertSample {
         Assert.assertTrue(b);
         Assert.assertTrue("Failure message to keep", b);
 
-        org.junit.Assert.assertFalse(b);
-        org.junit.Assert.assertFalse("Failure message to keep", b);
-        org.junit.Assert.assertTrue(b);
-        org.junit.Assert.assertTrue("Failure message to keep", b);
+        assertFalse(b);
+        assertFalse("Failure message to keep", b);
+        assertTrue(b);
+        assertTrue("Failure message to keep", b);
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
@@ -82,14 +82,14 @@ public class JUnitAssertSample {
         Assert.assertNotSame(o1, o2);
         Assert.assertNotSame("Failure message to keep", o1, o2);
 
-        org.junit.Assert.assertSame(o1, o2);
-        org.junit.Assert.assertSame("Failure message to keep", o1, o2);
-        org.junit.Assert.assertNotSame(o1, o2);
-        org.junit.Assert.assertNotSame("Failure message to keep", o1, o2);
-        org.junit.Assert.assertSame(o1, o2);
-        org.junit.Assert.assertSame("Failure message to keep", o1, o2);
-        org.junit.Assert.assertNotSame(o1, o2);
-        org.junit.Assert.assertNotSame("Failure message to keep", o1, o2);
+        assertSame(o1, o2);
+        assertSame("Failure message to keep", o1, o2);
+        assertNotSame(o1, o2);
+        assertNotSame("Failure message to keep", o1, o2);
+        assertSame(o1, o2);
+        assertSame("Failure message to keep", o1, o2);
+        assertNotSame(o1, o2);
+        assertNotSame("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
@@ -98,10 +98,10 @@ public class JUnitAssertSample {
         Assert.assertEquals(o1, o2);
         Assert.assertEquals("Failure message to keep", o1, o2);
 
-        org.junit.Assert.assertEquals(o1, o2);
-        org.junit.Assert.assertEquals("Failure message to keep", o1, o2);
-        org.junit.Assert.assertEquals(o1, o2);
-        org.junit.Assert.assertEquals("Failure message to keep", o1, o2);
+        assertEquals(o1, o2);
+        assertEquals("Failure message to keep", o1, o2);
+        assertEquals(o1, o2);
+        assertEquals("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
@@ -114,14 +114,14 @@ public class JUnitAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull("Failure message to keep", o);
 
-        org.junit.Assert.assertNull(o);
-        org.junit.Assert.assertNull("Failure message to keep", o);
-        org.junit.Assert.assertNotNull(o);
-        org.junit.Assert.assertNotNull("Failure message to keep", o);
-        org.junit.Assert.assertNull(o);
-        org.junit.Assert.assertNull("Failure message to keep", o);
-        org.junit.Assert.assertNotNull(o);
-        org.junit.Assert.assertNotNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
@@ -134,38 +134,38 @@ public class JUnitAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull("Failure message to keep", o);
 
-        org.junit.Assert.assertNull(o);
-        org.junit.Assert.assertNull("Failure message to keep", o);
-        org.junit.Assert.assertNotNull(o);
-        org.junit.Assert.assertNotNull("Failure message to keep", o);
-        org.junit.Assert.assertNull(o);
-        org.junit.Assert.assertNull("Failure message to keep", o);
-        org.junit.Assert.assertNotNull(o);
-        org.junit.Assert.assertNotNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
+        assertNotNull(o);
+        assertNotNull("Failure message to keep", o);
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
         Assert.assertNull(o);
         Assert.assertNull("Failure message to keep", o);
 
-        org.junit.Assert.assertNull(o);
-        org.junit.Assert.assertNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
         Assert.assertNull(o);
         Assert.assertNull("Failure message to keep", o);
 
-        org.junit.Assert.assertNull(o);
-        org.junit.Assert.assertNull("Failure message to keep", o);
+        assertNull(o);
+        assertNull("Failure message to keep", o);
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
         Assert.assertEquals(42, o);
         Assert.assertEquals("Failure message to keep", 42, o);
 
-        org.junit.Assert.assertEquals(42, o);
-        org.junit.Assert.assertEquals("Failure message to keep", 42, o);
+        assertEquals(42, o);
+        assertEquals("Failure message to keep", 42, o);
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -180,8 +180,8 @@ public class JUnitAssertSample {
         Assert.assertEquals(FOURTYTWO, o);
         Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
 
-        org.junit.Assert.assertEquals(FOURTYTWO, o);
-        org.junit.Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
+        assertEquals(FOURTYTWO, o);
+        assertEquals("Failure message to keep", FOURTYTWO, o);
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -196,12 +196,12 @@ public class JUnitAssertSample {
         Assert.assertEquals(expected, o);
         Assert.assertEquals("Failure message to keep", expected, o);
 
-        org.junit.Assert.assertEquals(expected, o);
-        org.junit.Assert.assertEquals("Failure message to keep", expected, o);
+        assertEquals(expected, o);
+        assertEquals("Failure message to keep", expected, o);
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        org.junit.Assert.assertEquals(expceted, o);
+        assertEquals(expceted, o);
     }
 
     public void doNotRefactorExpectedObjectAsExpectedArgWithEquals(Object o, int expected) throws Exception {
@@ -219,40 +219,40 @@ public class JUnitAssertSample {
         Assert.assertEquals(expected, l);
         Assert.assertEquals("Failure message to keep", expected, l);
 
-        org.junit.Assert.assertEquals(expected, l);
-        org.junit.Assert.assertEquals("Failure message to keep", expected, l);
+        assertEquals(expected, l);
+        assertEquals("Failure message to keep", expected, l);
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        org.junit.Assert.assertEquals(expceted, l);
+        assertEquals(expceted, l);
     }
 
     public void shouldMoveExpectedDoubleAsExpectedArgWithEquals(double d, double expected) throws Exception {
         Assert.assertEquals(expected, d);
         Assert.assertEquals("Failure message to keep", expected, d);
 
-        org.junit.Assert.assertEquals(expected, d);
-        org.junit.Assert.assertEquals("Failure message to keep", expected, d);
+        assertEquals(expected, d);
+        assertEquals("Failure message to keep", expected, d);
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        org.junit.Assert.assertEquals(expceted, d);
+        assertEquals(expceted, d);
     }
 
     public void shouldRefactorIfOnBoolean(boolean b) throws Exception {
         Assert.assertFalse(b);
         Assert.assertFalse("Failure message to keep", b);
 
-        org.junit.Assert.assertTrue(b);
-        org.junit.Assert.assertTrue("Failure message to keep", b);
+        assertTrue(b);
+        assertTrue("Failure message to keep", b);
     }
 
     public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
         Assert.assertEquals(i1, i2);
         Assert.assertEquals("Failure message to keep", i1, i2);
 
-        org.junit.Assert.assertEquals(i1, i2);
-        org.junit.Assert.assertEquals("Failure message to keep", i1, i2);
+        assertEquals(i1, i2);
+        assertEquals("Failure message to keep", i1, i2);
     }
 
     public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
@@ -261,10 +261,10 @@ public class JUnitAssertSample {
         Assert.assertSame(o1, o2);
         Assert.assertSame("Failure message to keep", o1, o2);
 
-        org.junit.Assert.assertNotSame(o1, o2);
-        org.junit.Assert.assertNotSame("Failure message to keep", o1, o2);
-        org.junit.Assert.assertSame(o1, o2);
-        org.junit.Assert.assertSame("Failure message to keep", o1, o2);
+        assertNotSame(o1, o2);
+        assertNotSame("Failure message to keep", o1, o2);
+        assertSame(o1, o2);
+        assertSame("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
@@ -277,22 +277,22 @@ public class JUnitAssertSample {
         Assert.assertNull(o1);
         Assert.assertNull("Failure message to keep", o1);
 
-        org.junit.Assert.assertNotNull(o1);
-        org.junit.Assert.assertNotNull("Failure message to keep", o1);
-        org.junit.Assert.assertNull(o1);
-        org.junit.Assert.assertNull("Failure message to keep", o1);
-        org.junit.Assert.assertNotNull(o1);
-        org.junit.Assert.assertNotNull("Failure message to keep", o1);
-        org.junit.Assert.assertNull(o1);
-        org.junit.Assert.assertNull("Failure message to keep", o1);
+        assertNotNull(o1);
+        assertNotNull("Failure message to keep", o1);
+        assertNull(o1);
+        assertNull("Failure message to keep", o1);
+        assertNotNull(o1);
+        assertNotNull("Failure message to keep", o1);
+        assertNull(o1);
+        assertNull("Failure message to keep", o1);
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
         Assert.assertEquals(o1, o2);
         Assert.assertEquals("Failure message to keep", o1, o2);
 
-        org.junit.Assert.assertEquals(o1, o2);
-        org.junit.Assert.assertEquals("Failure message to keep", o1, o2);
+        assertEquals(o1, o2);
+        assertEquals("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
@@ -305,14 +305,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(42, i);
         Assert.assertEquals("Failure message to keep", 42, i);
 
-        org.junit.Assert.assertNotEquals(42, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", 42, i);
-        org.junit.Assert.assertEquals(42, i);
-        org.junit.Assert.assertEquals("Failure message to keep", 42, i);
-        org.junit.Assert.assertNotEquals(42, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", 42, i);
-        org.junit.Assert.assertEquals(42, i);
-        org.junit.Assert.assertEquals("Failure message to keep", 42, i);
+        assertNotEquals(42, i);
+        assertNotEquals("Failure message to keep", 42, i);
+        assertEquals(42, i);
+        assertEquals("Failure message to keep", 42, i);
+        assertNotEquals(42, i);
+        assertNotEquals("Failure message to keep", 42, i);
+        assertEquals(42, i);
+        assertEquals("Failure message to keep", 42, i);
     }
 
     public void shouldRefactorIfConstantThenFail(int i) throws Exception {
@@ -325,14 +325,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(FOURTYTWO, i);
         Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
 
-        org.junit.Assert.assertNotEquals(FOURTYTWO, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", FOURTYTWO, i);
-        org.junit.Assert.assertEquals(FOURTYTWO, i);
-        org.junit.Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
-        org.junit.Assert.assertNotEquals(FOURTYTWO, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", FOURTYTWO, i);
-        org.junit.Assert.assertEquals(FOURTYTWO, i);
-        org.junit.Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
+        assertNotEquals(FOURTYTWO, i);
+        assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        assertEquals(FOURTYTWO, i);
+        assertEquals("Failure message to keep", FOURTYTWO, i);
+        assertNotEquals(FOURTYTWO, i);
+        assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        assertEquals(FOURTYTWO, i);
+        assertEquals("Failure message to keep", FOURTYTWO, i);
     }
 
     public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
@@ -345,14 +345,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(expected, i);
         Assert.assertEquals("Failure message to keep", expected, i);
 
-        org.junit.Assert.assertNotEquals(expected, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", expected, i);
-        org.junit.Assert.assertEquals(expected, i);
-        org.junit.Assert.assertEquals("Failure message to keep", expected, i);
-        org.junit.Assert.assertNotEquals(expected, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", expected, i);
-        org.junit.Assert.assertEquals(expected, i);
-        org.junit.Assert.assertEquals("Failure message to keep", expected, i);
+        assertNotEquals(expected, i);
+        assertNotEquals("Failure message to keep", expected, i);
+        assertEquals(expected, i);
+        assertEquals("Failure message to keep", expected, i);
+        assertNotEquals(expected, i);
+        assertNotEquals("Failure message to keep", expected, i);
+        assertEquals(expected, i);
+        assertEquals("Failure message to keep", expected, i);
     }
 
     public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
@@ -365,14 +365,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(expectedI, i);
         Assert.assertEquals("Failure message to keep", expectedI, i);
 
-        org.junit.Assert.assertNotEquals(expectedI, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", expectedI, i);
-        org.junit.Assert.assertEquals(expectedI, i);
-        org.junit.Assert.assertEquals("Failure message to keep", expectedI, i);
-        org.junit.Assert.assertNotEquals(expectedI, i);
-        org.junit.Assert.assertNotEquals("Failure message to keep", expectedI, i);
-        org.junit.Assert.assertEquals(expectedI, i);
-        org.junit.Assert.assertEquals("Failure message to keep", expectedI, i);
+        assertNotEquals(expectedI, i);
+        assertNotEquals("Failure message to keep", expectedI, i);
+        assertEquals(expectedI, i);
+        assertEquals("Failure message to keep", expectedI, i);
+        assertNotEquals(expectedI, i);
+        assertNotEquals("Failure message to keep", expectedI, i);
+        assertEquals(expectedI, i);
+        assertEquals("Failure message to keep", expectedI, i);
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/JUnitAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/JUnitAssertSample.java
@@ -39,10 +39,10 @@ public class JUnitAssertSample {
         Assert.assertEquals(i1, i2);
         Assert.assertEquals("Failure message to keep", i1, i2);
 
-        assertEquals(i1, i2);
-        assertEquals("Failure message to keep", i1, i2);
-        assertEquals(i1, i2);
-        assertEquals("Failure message to keep", i1, i2);
+        org.junit.Assert.assertEquals(i1, i2);
+        org.junit.Assert.assertEquals("Failure message to keep", i1, i2);
+        org.junit.Assert.assertEquals(i1, i2);
+        org.junit.Assert.assertEquals("Failure message to keep", i1, i2);
     }
 
     public void shouldRefactorFailures() throws Exception {
@@ -51,10 +51,10 @@ public class JUnitAssertSample {
         Assert.fail();
         Assert.fail("Failure message to keep");
 
-        fail();
-        fail("Failure message to keep");
-        fail();
-        fail("Failure message to keep");
+        org.junit.Assert.fail();
+        org.junit.Assert.fail("Failure message to keep");
+        org.junit.Assert.fail();
+        org.junit.Assert.fail("Failure message to keep");
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
@@ -66,10 +66,10 @@ public class JUnitAssertSample {
         Assert.assertTrue(b);
         Assert.assertTrue("Failure message to keep", b);
 
-        assertFalse(b);
-        assertFalse("Failure message to keep", b);
-        assertTrue(b);
-        assertTrue("Failure message to keep", b);
+        org.junit.Assert.assertFalse(b);
+        org.junit.Assert.assertFalse("Failure message to keep", b);
+        org.junit.Assert.assertTrue(b);
+        org.junit.Assert.assertTrue("Failure message to keep", b);
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
@@ -82,14 +82,14 @@ public class JUnitAssertSample {
         Assert.assertNotSame(o1, o2);
         Assert.assertNotSame("Failure message to keep", o1, o2);
 
-        assertSame(o1, o2);
-        assertSame("Failure message to keep", o1, o2);
-        assertNotSame(o1, o2);
-        assertNotSame("Failure message to keep", o1, o2);
-        assertSame(o1, o2);
-        assertSame("Failure message to keep", o1, o2);
-        assertNotSame(o1, o2);
-        assertNotSame("Failure message to keep", o1, o2);
+        org.junit.Assert.assertSame(o1, o2);
+        org.junit.Assert.assertSame("Failure message to keep", o1, o2);
+        org.junit.Assert.assertNotSame(o1, o2);
+        org.junit.Assert.assertNotSame("Failure message to keep", o1, o2);
+        org.junit.Assert.assertSame(o1, o2);
+        org.junit.Assert.assertSame("Failure message to keep", o1, o2);
+        org.junit.Assert.assertNotSame(o1, o2);
+        org.junit.Assert.assertNotSame("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
@@ -98,10 +98,10 @@ public class JUnitAssertSample {
         Assert.assertEquals(o1, o2);
         Assert.assertEquals("Failure message to keep", o1, o2);
 
-        assertEquals(o1, o2);
-        assertEquals("Failure message to keep", o1, o2);
-        assertEquals(o1, o2);
-        assertEquals("Failure message to keep", o1, o2);
+        org.junit.Assert.assertEquals(o1, o2);
+        org.junit.Assert.assertEquals("Failure message to keep", o1, o2);
+        org.junit.Assert.assertEquals(o1, o2);
+        org.junit.Assert.assertEquals("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
@@ -114,14 +114,14 @@ public class JUnitAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull("Failure message to keep", o);
 
-        assertNull(o);
-        assertNull("Failure message to keep", o);
-        assertNotNull(o);
-        assertNotNull("Failure message to keep", o);
-        assertNull(o);
-        assertNull("Failure message to keep", o);
-        assertNotNull(o);
-        assertNotNull("Failure message to keep", o);
+        org.junit.Assert.assertNull(o);
+        org.junit.Assert.assertNull("Failure message to keep", o);
+        org.junit.Assert.assertNotNull(o);
+        org.junit.Assert.assertNotNull("Failure message to keep", o);
+        org.junit.Assert.assertNull(o);
+        org.junit.Assert.assertNull("Failure message to keep", o);
+        org.junit.Assert.assertNotNull(o);
+        org.junit.Assert.assertNotNull("Failure message to keep", o);
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
@@ -134,38 +134,38 @@ public class JUnitAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull("Failure message to keep", o);
 
-        assertNull(o);
-        assertNull("Failure message to keep", o);
-        assertNotNull(o);
-        assertNotNull("Failure message to keep", o);
-        assertNull(o);
-        assertNull("Failure message to keep", o);
-        assertNotNull(o);
-        assertNotNull("Failure message to keep", o);
+        org.junit.Assert.assertNull(o);
+        org.junit.Assert.assertNull("Failure message to keep", o);
+        org.junit.Assert.assertNotNull(o);
+        org.junit.Assert.assertNotNull("Failure message to keep", o);
+        org.junit.Assert.assertNull(o);
+        org.junit.Assert.assertNull("Failure message to keep", o);
+        org.junit.Assert.assertNotNull(o);
+        org.junit.Assert.assertNotNull("Failure message to keep", o);
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
         Assert.assertNull(o);
         Assert.assertNull("Failure message to keep", o);
 
-        assertNull(o);
-        assertNull("Failure message to keep", o);
+        org.junit.Assert.assertNull(o);
+        org.junit.Assert.assertNull("Failure message to keep", o);
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
         Assert.assertNull(o);
         Assert.assertNull("Failure message to keep", o);
 
-        assertNull(o);
-        assertNull("Failure message to keep", o);
+        org.junit.Assert.assertNull(o);
+        org.junit.Assert.assertNull("Failure message to keep", o);
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
         Assert.assertEquals(42, o);
         Assert.assertEquals("Failure message to keep", 42, o);
 
-        assertEquals(42, o);
-        assertEquals("Failure message to keep", 42, o);
+        org.junit.Assert.assertEquals(42, o);
+        org.junit.Assert.assertEquals("Failure message to keep", 42, o);
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -180,8 +180,8 @@ public class JUnitAssertSample {
         Assert.assertEquals(FOURTYTWO, o);
         Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
 
-        assertEquals(FOURTYTWO, o);
-        assertEquals("Failure message to keep", FOURTYTWO, o);
+        org.junit.Assert.assertEquals(FOURTYTWO, o);
+        org.junit.Assert.assertEquals("Failure message to keep", FOURTYTWO, o);
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -196,12 +196,12 @@ public class JUnitAssertSample {
         Assert.assertEquals(expected, o);
         Assert.assertEquals("Failure message to keep", expected, o);
 
-        assertEquals(expected, o);
-        assertEquals("Failure message to keep", expected, o);
+        org.junit.Assert.assertEquals(expected, o);
+        org.junit.Assert.assertEquals("Failure message to keep", expected, o);
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        assertEquals(expceted, o);
+        org.junit.Assert.assertEquals(expceted, o);
     }
 
     public void doNotRefactorExpectedObjectAsExpectedArgWithEquals(Object o, int expected) throws Exception {
@@ -219,40 +219,40 @@ public class JUnitAssertSample {
         Assert.assertEquals(expected, l);
         Assert.assertEquals("Failure message to keep", expected, l);
 
-        assertEquals(expected, l);
-        assertEquals("Failure message to keep", expected, l);
+        org.junit.Assert.assertEquals(expected, l);
+        org.junit.Assert.assertEquals("Failure message to keep", expected, l);
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        assertEquals(expceted, l);
+        org.junit.Assert.assertEquals(expceted, l);
     }
 
     public void shouldMoveExpectedDoubleAsExpectedArgWithEquals(double d, double expected) throws Exception {
         Assert.assertEquals(expected, d);
         Assert.assertEquals("Failure message to keep", expected, d);
 
-        assertEquals(expected, d);
-        assertEquals("Failure message to keep", expected, d);
+        org.junit.Assert.assertEquals(expected, d);
+        org.junit.Assert.assertEquals("Failure message to keep", expected, d);
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        assertEquals(expceted, d);
+        org.junit.Assert.assertEquals(expceted, d);
     }
 
     public void shouldRefactorIfOnBoolean(boolean b) throws Exception {
         Assert.assertFalse(b);
         Assert.assertFalse("Failure message to keep", b);
 
-        assertTrue(b);
-        assertTrue("Failure message to keep", b);
+        org.junit.Assert.assertTrue(b);
+        org.junit.Assert.assertTrue("Failure message to keep", b);
     }
 
     public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
         Assert.assertEquals(i1, i2);
         Assert.assertEquals("Failure message to keep", i1, i2);
 
-        assertEquals(i1, i2);
-        assertEquals("Failure message to keep", i1, i2);
+        org.junit.Assert.assertEquals(i1, i2);
+        org.junit.Assert.assertEquals("Failure message to keep", i1, i2);
     }
 
     public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
@@ -261,10 +261,10 @@ public class JUnitAssertSample {
         Assert.assertSame(o1, o2);
         Assert.assertSame("Failure message to keep", o1, o2);
 
-        assertNotSame(o1, o2);
-        assertNotSame("Failure message to keep", o1, o2);
-        assertSame(o1, o2);
-        assertSame("Failure message to keep", o1, o2);
+        org.junit.Assert.assertNotSame(o1, o2);
+        org.junit.Assert.assertNotSame("Failure message to keep", o1, o2);
+        org.junit.Assert.assertSame(o1, o2);
+        org.junit.Assert.assertSame("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
@@ -277,22 +277,22 @@ public class JUnitAssertSample {
         Assert.assertNull(o1);
         Assert.assertNull("Failure message to keep", o1);
 
-        assertNotNull(o1);
-        assertNotNull("Failure message to keep", o1);
-        assertNull(o1);
-        assertNull("Failure message to keep", o1);
-        assertNotNull(o1);
-        assertNotNull("Failure message to keep", o1);
-        assertNull(o1);
-        assertNull("Failure message to keep", o1);
+        org.junit.Assert.assertNotNull(o1);
+        org.junit.Assert.assertNotNull("Failure message to keep", o1);
+        org.junit.Assert.assertNull(o1);
+        org.junit.Assert.assertNull("Failure message to keep", o1);
+        org.junit.Assert.assertNotNull(o1);
+        org.junit.Assert.assertNotNull("Failure message to keep", o1);
+        org.junit.Assert.assertNull(o1);
+        org.junit.Assert.assertNull("Failure message to keep", o1);
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
         Assert.assertEquals(o1, o2);
         Assert.assertEquals("Failure message to keep", o1, o2);
 
-        assertEquals(o1, o2);
-        assertEquals("Failure message to keep", o1, o2);
+        org.junit.Assert.assertEquals(o1, o2);
+        org.junit.Assert.assertEquals("Failure message to keep", o1, o2);
     }
 
     public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
@@ -305,14 +305,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(42, i);
         Assert.assertEquals("Failure message to keep", 42, i);
 
-        assertNotEquals(42, i);
-        assertNotEquals("Failure message to keep", 42, i);
-        assertEquals(42, i);
-        assertEquals("Failure message to keep", 42, i);
-        assertNotEquals(42, i);
-        assertNotEquals("Failure message to keep", 42, i);
-        assertEquals(42, i);
-        assertEquals("Failure message to keep", 42, i);
+        org.junit.Assert.assertNotEquals(42, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", 42, i);
+        org.junit.Assert.assertEquals(42, i);
+        org.junit.Assert.assertEquals("Failure message to keep", 42, i);
+        org.junit.Assert.assertNotEquals(42, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", 42, i);
+        org.junit.Assert.assertEquals(42, i);
+        org.junit.Assert.assertEquals("Failure message to keep", 42, i);
     }
 
     public void shouldRefactorIfConstantThenFail(int i) throws Exception {
@@ -325,14 +325,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(FOURTYTWO, i);
         Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
 
-        assertNotEquals(FOURTYTWO, i);
-        assertNotEquals("Failure message to keep", FOURTYTWO, i);
-        assertEquals(FOURTYTWO, i);
-        assertEquals("Failure message to keep", FOURTYTWO, i);
-        assertNotEquals(FOURTYTWO, i);
-        assertNotEquals("Failure message to keep", FOURTYTWO, i);
-        assertEquals(FOURTYTWO, i);
-        assertEquals("Failure message to keep", FOURTYTWO, i);
+        org.junit.Assert.assertNotEquals(FOURTYTWO, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        org.junit.Assert.assertEquals(FOURTYTWO, i);
+        org.junit.Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
+        org.junit.Assert.assertNotEquals(FOURTYTWO, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", FOURTYTWO, i);
+        org.junit.Assert.assertEquals(FOURTYTWO, i);
+        org.junit.Assert.assertEquals("Failure message to keep", FOURTYTWO, i);
     }
 
     public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
@@ -345,14 +345,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(expected, i);
         Assert.assertEquals("Failure message to keep", expected, i);
 
-        assertNotEquals(expected, i);
-        assertNotEquals("Failure message to keep", expected, i);
-        assertEquals(expected, i);
-        assertEquals("Failure message to keep", expected, i);
-        assertNotEquals(expected, i);
-        assertNotEquals("Failure message to keep", expected, i);
-        assertEquals(expected, i);
-        assertEquals("Failure message to keep", expected, i);
+        org.junit.Assert.assertNotEquals(expected, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", expected, i);
+        org.junit.Assert.assertEquals(expected, i);
+        org.junit.Assert.assertEquals("Failure message to keep", expected, i);
+        org.junit.Assert.assertNotEquals(expected, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", expected, i);
+        org.junit.Assert.assertEquals(expected, i);
+        org.junit.Assert.assertEquals("Failure message to keep", expected, i);
     }
 
     public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
@@ -365,14 +365,14 @@ public class JUnitAssertSample {
         Assert.assertEquals(expectedI, i);
         Assert.assertEquals("Failure message to keep", expectedI, i);
 
-        assertNotEquals(expectedI, i);
-        assertNotEquals("Failure message to keep", expectedI, i);
-        assertEquals(expectedI, i);
-        assertEquals("Failure message to keep", expectedI, i);
-        assertNotEquals(expectedI, i);
-        assertNotEquals("Failure message to keep", expectedI, i);
-        assertEquals(expectedI, i);
-        assertEquals("Failure message to keep", expectedI, i);
+        org.junit.Assert.assertNotEquals(expectedI, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", expectedI, i);
+        org.junit.Assert.assertEquals(expectedI, i);
+        org.junit.Assert.assertEquals("Failure message to keep", expectedI, i);
+        org.junit.Assert.assertNotEquals(expectedI, i);
+        org.junit.Assert.assertNotEquals("Failure message to keep", expectedI, i);
+        org.junit.Assert.assertEquals(expectedI, i);
+        org.junit.Assert.assertEquals("Failure message to keep", expectedI, i);
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/TestNGAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/TestNGAssertSample.java
@@ -46,14 +46,14 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(i1, i2);
         Assert.assertNotEquals(i1, i2, "Failure message to keep");
 
-        assertEquals(i1, i2);
-        assertEquals(i1, i2, "Failure message to keep");
-        assertNotEquals(i1, i2);
-        assertNotEquals(i1, i2, "Failure message to keep");
-        assertEquals(i1, i2);
-        assertEquals(i1, i2, "Failure message to keep");
-        assertNotEquals(i1, i2);
-        assertNotEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertEquals(i1, i2);
+        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i1, i2);
+        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertEquals(i1, i2);
+        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i1, i2);
+        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
     }
 
     public void shouldRefactorFailures() throws Exception {
@@ -62,10 +62,10 @@ public class TestNGAssertSample {
         Assert.fail();
         Assert.fail("Failure message to keep");
 
-        fail();
-        fail("Failure message to keep");
-        fail();
-        fail("Failure message to keep");
+        org.testng.Assert.fail();
+        org.testng.Assert.fail("Failure message to keep");
+        org.testng.Assert.fail();
+        org.testng.Assert.fail("Failure message to keep");
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
@@ -77,10 +77,10 @@ public class TestNGAssertSample {
         Assert.assertTrue(b);
         Assert.assertTrue(b, "Failure message to keep");
 
-        assertFalse(b);
-        assertFalse(b, "Failure message to keep");
-        assertTrue(b);
-        assertTrue(b, "Failure message to keep");
+        org.testng.Assert.assertFalse(b);
+        org.testng.Assert.assertFalse(b, "Failure message to keep");
+        org.testng.Assert.assertTrue(b);
+        org.testng.Assert.assertTrue(b, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
@@ -93,14 +93,14 @@ public class TestNGAssertSample {
         Assert.assertNotSame(o1, o2);
         Assert.assertNotSame(o1, o2, "Failure message to keep");
 
-        assertSame(o1, o2);
-        assertSame(o1, o2, "Failure message to keep");
-        assertNotSame(o1, o2);
-        assertNotSame(o1, o2, "Failure message to keep");
-        assertSame(o1, o2);
-        assertSame(o1, o2, "Failure message to keep");
-        assertNotSame(o1, o2);
-        assertNotSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertSame(o1, o2);
+        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotSame(o1, o2);
+        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertSame(o1, o2);
+        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotSame(o1, o2);
+        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
@@ -113,14 +113,14 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o1, o2);
         Assert.assertNotEquals(o1, o2, "Failure message to keep");
 
-        assertEquals(o1, o2);
-        assertEquals(o1, o2, "Failure message to keep");
-        assertNotEquals(o1, o2);
-        assertNotEquals(o1, o2, "Failure message to keep");
-        assertEquals(o1, o2);
-        assertEquals(o1, o2, "Failure message to keep");
-        assertNotEquals(o1, o2);
-        assertNotEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertEquals(o1, o2);
+        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o1, o2);
+        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertEquals(o1, o2);
+        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o1, o2);
+        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
@@ -133,14 +133,14 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        assertNull(o);
-        assertNull(o, "Failure message to keep");
-        assertNotNull(o);
-        assertNotNull(o, "Failure message to keep");
-        assertNull(o);
-        assertNull(o, "Failure message to keep");
-        assertNotNull(o);
-        assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
@@ -153,14 +153,14 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        assertNull(o);
-        assertNull(o, "Failure message to keep");
-        assertNotNull(o);
-        assertNotNull(o, "Failure message to keep");
-        assertNull(o);
-        assertNull(o, "Failure message to keep");
-        assertNotNull(o);
-        assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
@@ -169,10 +169,10 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        assertNull(o);
-        assertNull(o, "Failure message to keep");
-        assertNotNull(o);
-        assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
@@ -181,10 +181,10 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        assertNull(o);
-        assertNull(o, "Failure message to keep");
-        assertNotNull(o);
-        assertNotNull(o, "Failure message to keep");
+        org.testng.Assert.assertNull(o);
+        org.testng.Assert.assertNull(o, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o);
+        org.testng.Assert.assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -193,10 +193,10 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o, 42);
         Assert.assertNotEquals(o, 42, "Failure message to keep");
 
-        assertEquals(o, 42);
-        assertEquals(o, 42, "Failure message to keep");
-        assertNotEquals(o, 42);
-        assertNotEquals(o, 42, "Failure message to keep");
+        org.testng.Assert.assertEquals(o, 42);
+        org.testng.Assert.assertEquals(o, 42, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o, 42);
+        org.testng.Assert.assertNotEquals(o, 42, "Failure message to keep");
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -217,10 +217,10 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o, FOURTYTWO);
         Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
 
-        assertEquals(o, FOURTYTWO);
-        assertEquals(o, FOURTYTWO, "Failure message to keep");
-        assertNotEquals(o, FOURTYTWO);
-        assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertEquals(o, FOURTYTWO);
+        org.testng.Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o, FOURTYTWO);
+        org.testng.Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -241,14 +241,14 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o, expected);
         Assert.assertNotEquals(o, expected, "Failure message to keep");
 
-        assertEquals(o, expected);
-        assertEquals(o, expected, "Failure message to keep");
-        assertNotEquals(o, expected);
-        assertNotEquals(o, expected, "Failure message to keep");
+        org.testng.Assert.assertEquals(o, expected);
+        org.testng.Assert.assertEquals(o, expected, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o, expected);
+        org.testng.Assert.assertNotEquals(o, expected, "Failure message to keep");
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        assertEquals(o, expceted);
+        org.testng.Assert.assertEquals(o, expceted);
     }
 
     public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
@@ -257,10 +257,10 @@ public class TestNGAssertSample {
         Assert.assertEquals(i1, i2);
         Assert.assertEquals(i1, i2, "Failure message to keep");
 
-        assertNotEquals(i1, i2);
-        assertNotEquals(i1, i2, "Failure message to keep");
-        assertEquals(i1, i2);
-        assertEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i1, i2);
+        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        org.testng.Assert.assertEquals(i1, i2);
+        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
     }
 
     public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
@@ -269,10 +269,10 @@ public class TestNGAssertSample {
         Assert.assertSame(o1, o2);
         Assert.assertSame(o1, o2, "Failure message to keep");
 
-        assertNotSame(o1, o2);
-        assertNotSame(o1, o2, "Failure message to keep");
-        assertSame(o1, o2);
-        assertSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotSame(o1, o2);
+        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertSame(o1, o2);
+        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
@@ -285,14 +285,14 @@ public class TestNGAssertSample {
         Assert.assertNull(o1);
         Assert.assertNull(o1, "Failure message to keep");
 
-        assertNotNull(o1);
-        assertNotNull(o1, "Failure message to keep");
-        assertNull(o1);
-        assertNull(o1, "Failure message to keep");
-        assertNotNull(o1);
-        assertNotNull(o1, "Failure message to keep");
-        assertNull(o1);
-        assertNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o1);
+        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNull(o1);
+        org.testng.Assert.assertNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNotNull(o1);
+        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
+        org.testng.Assert.assertNull(o1);
+        org.testng.Assert.assertNull(o1, "Failure message to keep");
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
@@ -301,10 +301,10 @@ public class TestNGAssertSample {
         Assert.assertEquals(o1, o2);
         Assert.assertEquals(o1, o2, "Failure message to keep");
 
-        assertNotEquals(o1, o2);
-        assertNotEquals(o1, o2, "Failure message to keep");
-        assertEquals(o1, o2);
-        assertEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(o1, o2);
+        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        org.testng.Assert.assertEquals(o1, o2);
+        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
@@ -317,14 +317,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, 42);
         Assert.assertEquals(i, 42, "Failure message to keep");
 
-        assertNotEquals(i, 42);
-        assertNotEquals(i, 42, "Failure message to keep");
-        assertEquals(i, 42);
-        assertEquals(i, 42, "Failure message to keep");
-        assertNotEquals(i, 42);
-        assertNotEquals(i, 42, "Failure message to keep");
-        assertEquals(i, 42);
-        assertEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, 42);
+        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, 42);
+        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, 42);
+        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, 42);
+        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
     }
 
     public void shouldRefactorIfConstantThenFail(int i) throws Exception {
@@ -337,14 +337,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, FOURTYTWO);
         Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
 
-        assertNotEquals(i, FOURTYTWO);
-        assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        assertEquals(i, FOURTYTWO);
-        assertEquals(i, FOURTYTWO, "Failure message to keep");
-        assertNotEquals(i, FOURTYTWO);
-        assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        assertEquals(i, FOURTYTWO);
-        assertEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, FOURTYTWO);
+        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
+        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, FOURTYTWO);
+        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
     }
 
     public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
@@ -357,14 +357,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, expected);
         Assert.assertEquals(i, expected, "Failure message to keep");
 
-        assertNotEquals(i, expected);
-        assertNotEquals(i, expected, "Failure message to keep");
-        assertEquals(i, expected);
-        assertEquals(i, expected, "Failure message to keep");
-        assertNotEquals(i, expected);
-        assertNotEquals(i, expected, "Failure message to keep");
-        assertEquals(i, expected);
-        assertEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, expected);
+        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expected);
+        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, expected);
+        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expected);
+        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
     }
 
     public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
@@ -377,14 +377,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, expectedI);
         Assert.assertEquals(i, expectedI, "Failure message to keep");
 
-        assertNotEquals(i, expectedI);
-        assertNotEquals(i, expectedI, "Failure message to keep");
-        assertEquals(i, expectedI);
-        assertEquals(i, expectedI, "Failure message to keep");
-        assertNotEquals(i, expectedI);
-        assertNotEquals(i, expectedI, "Failure message to keep");
-        assertEquals(i, expectedI);
-        assertEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, expectedI);
+        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expectedI);
+        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertNotEquals(i, expectedI);
+        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        org.testng.Assert.assertEquals(i, expectedI);
+        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/TestNGAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/TestNGAssertSample.java
@@ -46,14 +46,14 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(i1, i2);
         Assert.assertNotEquals(i1, i2, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(i1, i2);
-        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i1, i2);
-        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertEquals(i1, i2);
-        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i1, i2);
-        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
+        assertEquals(i1, i2);
+        assertEquals(i1, i2, "Failure message to keep");
+        assertNotEquals(i1, i2);
+        assertNotEquals(i1, i2, "Failure message to keep");
+        assertEquals(i1, i2);
+        assertEquals(i1, i2, "Failure message to keep");
+        assertNotEquals(i1, i2);
+        assertNotEquals(i1, i2, "Failure message to keep");
     }
 
     public void shouldRefactorFailures() throws Exception {
@@ -62,10 +62,10 @@ public class TestNGAssertSample {
         Assert.fail();
         Assert.fail("Failure message to keep");
 
-        org.testng.Assert.fail();
-        org.testng.Assert.fail("Failure message to keep");
-        org.testng.Assert.fail();
-        org.testng.Assert.fail("Failure message to keep");
+        fail();
+        fail("Failure message to keep");
+        fail();
+        fail("Failure message to keep");
     }
 
     public void shouldRemoveDeadChecks() throws Exception {
@@ -77,10 +77,10 @@ public class TestNGAssertSample {
         Assert.assertTrue(b);
         Assert.assertTrue(b, "Failure message to keep");
 
-        org.testng.Assert.assertFalse(b);
-        org.testng.Assert.assertFalse(b, "Failure message to keep");
-        org.testng.Assert.assertTrue(b);
-        org.testng.Assert.assertTrue(b, "Failure message to keep");
+        assertFalse(b);
+        assertFalse(b, "Failure message to keep");
+        assertTrue(b);
+        assertTrue(b, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjectReferences(Object o1, Object o2) throws Exception {
@@ -93,14 +93,14 @@ public class TestNGAssertSample {
         Assert.assertNotSame(o1, o2);
         Assert.assertNotSame(o1, o2, "Failure message to keep");
 
-        org.testng.Assert.assertSame(o1, o2);
-        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotSame(o1, o2);
-        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertSame(o1, o2);
-        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotSame(o1, o2);
-        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
+        assertSame(o1, o2);
+        assertSame(o1, o2, "Failure message to keep");
+        assertNotSame(o1, o2);
+        assertNotSame(o1, o2, "Failure message to keep");
+        assertSame(o1, o2);
+        assertSame(o1, o2, "Failure message to keep");
+        assertNotSame(o1, o2);
+        assertNotSame(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorWithObjects(Object o1, Object o2) throws Exception {
@@ -113,14 +113,14 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o1, o2);
         Assert.assertNotEquals(o1, o2, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o1, o2);
-        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o1, o2);
-        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertEquals(o1, o2);
-        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o1, o2);
-        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
+        assertEquals(o1, o2);
+        assertEquals(o1, o2, "Failure message to keep");
+        assertNotEquals(o1, o2);
+        assertNotEquals(o1, o2, "Failure message to keep");
+        assertEquals(o1, o2);
+        assertEquals(o1, o2, "Failure message to keep");
+        assertNotEquals(o1, o2);
+        assertNotEquals(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArg(Object o) throws Exception {
@@ -133,14 +133,14 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertNull(o);
+        assertNull(o, "Failure message to keep");
+        assertNotNull(o);
+        assertNotNull(o, "Failure message to keep");
+        assertNull(o);
+        assertNull(o, "Failure message to keep");
+        assertNotNull(o);
+        assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArg(Object o) throws Exception {
@@ -153,14 +153,14 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertNull(o);
+        assertNull(o, "Failure message to keep");
+        assertNotNull(o);
+        assertNotNull(o, "Failure message to keep");
+        assertNull(o);
+        assertNull(o, "Failure message to keep");
+        assertNotNull(o);
+        assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckFirstArgWithEquals(Object o) throws Exception {
@@ -169,10 +169,10 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertNull(o);
+        assertNull(o, "Failure message to keep");
+        assertNotNull(o);
+        assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldRefactorNullCheckSecondArgWithEquals(Object o) throws Exception {
@@ -181,10 +181,10 @@ public class TestNGAssertSample {
         Assert.assertNotNull(o);
         Assert.assertNotNull(o, "Failure message to keep");
 
-        org.testng.Assert.assertNull(o);
-        org.testng.Assert.assertNull(o, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o);
-        org.testng.Assert.assertNotNull(o, "Failure message to keep");
+        assertNull(o);
+        assertNull(o, "Failure message to keep");
+        assertNotNull(o);
+        assertNotNull(o, "Failure message to keep");
     }
 
     public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -193,10 +193,10 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o, 42);
         Assert.assertNotEquals(o, 42, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o, 42);
-        org.testng.Assert.assertEquals(o, 42, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o, 42);
-        org.testng.Assert.assertNotEquals(o, 42, "Failure message to keep");
+        assertEquals(o, 42);
+        assertEquals(o, 42, "Failure message to keep");
+        assertNotEquals(o, 42);
+        assertNotEquals(o, 42, "Failure message to keep");
     }
 
     public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -217,10 +217,10 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o, FOURTYTWO);
         Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o, FOURTYTWO);
-        org.testng.Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o, FOURTYTWO);
-        org.testng.Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+        assertEquals(o, FOURTYTWO);
+        assertEquals(o, FOURTYTWO, "Failure message to keep");
+        assertNotEquals(o, FOURTYTWO);
+        assertNotEquals(o, FOURTYTWO, "Failure message to keep");
     }
 
     public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
@@ -241,14 +241,14 @@ public class TestNGAssertSample {
         Assert.assertNotEquals(o, expected);
         Assert.assertNotEquals(o, expected, "Failure message to keep");
 
-        org.testng.Assert.assertEquals(o, expected);
-        org.testng.Assert.assertEquals(o, expected, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(o, expected);
-        org.testng.Assert.assertNotEquals(o, expected, "Failure message to keep");
+        assertEquals(o, expected);
+        assertEquals(o, expected, "Failure message to keep");
+        assertNotEquals(o, expected);
+        assertNotEquals(o, expected, "Failure message to keep");
 
         // tests that this works according to levenshtein distance
         int expceted = 0;
-        org.testng.Assert.assertEquals(o, expceted);
+        assertEquals(o, expceted);
     }
 
     public void shouldRefactorIfPrimitiveThenFail(int i1, int i2) throws Exception {
@@ -257,10 +257,10 @@ public class TestNGAssertSample {
         Assert.assertEquals(i1, i2);
         Assert.assertEquals(i1, i2, "Failure message to keep");
 
-        org.testng.Assert.assertNotEquals(i1, i2);
-        org.testng.Assert.assertNotEquals(i1, i2, "Failure message to keep");
-        org.testng.Assert.assertEquals(i1, i2);
-        org.testng.Assert.assertEquals(i1, i2, "Failure message to keep");
+        assertNotEquals(i1, i2);
+        assertNotEquals(i1, i2, "Failure message to keep");
+        assertEquals(i1, i2);
+        assertEquals(i1, i2, "Failure message to keep");
     }
 
     public void shouldRefactorIfSameObjectThenFail(Object o1, Object o2) throws Exception {
@@ -269,10 +269,10 @@ public class TestNGAssertSample {
         Assert.assertSame(o1, o2);
         Assert.assertSame(o1, o2, "Failure message to keep");
 
-        org.testng.Assert.assertNotSame(o1, o2);
-        org.testng.Assert.assertNotSame(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertSame(o1, o2);
-        org.testng.Assert.assertSame(o1, o2, "Failure message to keep");
+        assertNotSame(o1, o2);
+        assertNotSame(o1, o2, "Failure message to keep");
+        assertSame(o1, o2);
+        assertSame(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorIfNullThenFail(Object o1) throws Exception {
@@ -285,14 +285,14 @@ public class TestNGAssertSample {
         Assert.assertNull(o1);
         Assert.assertNull(o1, "Failure message to keep");
 
-        org.testng.Assert.assertNotNull(o1);
-        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
-        org.testng.Assert.assertNull(o1);
-        org.testng.Assert.assertNull(o1, "Failure message to keep");
-        org.testng.Assert.assertNotNull(o1);
-        org.testng.Assert.assertNotNull(o1, "Failure message to keep");
-        org.testng.Assert.assertNull(o1);
-        org.testng.Assert.assertNull(o1, "Failure message to keep");
+        assertNotNull(o1);
+        assertNotNull(o1, "Failure message to keep");
+        assertNull(o1);
+        assertNull(o1, "Failure message to keep");
+        assertNotNull(o1);
+        assertNotNull(o1, "Failure message to keep");
+        assertNull(o1);
+        assertNull(o1, "Failure message to keep");
     }
 
     public void shouldRefactorIfObjectThenFail(Object o1, Object o2) throws Exception {
@@ -301,10 +301,10 @@ public class TestNGAssertSample {
         Assert.assertEquals(o1, o2);
         Assert.assertEquals(o1, o2, "Failure message to keep");
 
-        org.testng.Assert.assertNotEquals(o1, o2);
-        org.testng.Assert.assertNotEquals(o1, o2, "Failure message to keep");
-        org.testng.Assert.assertEquals(o1, o2);
-        org.testng.Assert.assertEquals(o1, o2, "Failure message to keep");
+        assertNotEquals(o1, o2);
+        assertNotEquals(o1, o2, "Failure message to keep");
+        assertEquals(o1, o2);
+        assertEquals(o1, o2, "Failure message to keep");
     }
 
     public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
@@ -317,14 +317,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, 42);
         Assert.assertEquals(i, 42, "Failure message to keep");
 
-        org.testng.Assert.assertNotEquals(i, 42);
-        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, 42);
-        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, 42);
-        org.testng.Assert.assertNotEquals(i, 42, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, 42);
-        org.testng.Assert.assertEquals(i, 42, "Failure message to keep");
+        assertNotEquals(i, 42);
+        assertNotEquals(i, 42, "Failure message to keep");
+        assertEquals(i, 42);
+        assertEquals(i, 42, "Failure message to keep");
+        assertNotEquals(i, 42);
+        assertNotEquals(i, 42, "Failure message to keep");
+        assertEquals(i, 42);
+        assertEquals(i, 42, "Failure message to keep");
     }
 
     public void shouldRefactorIfConstantThenFail(int i) throws Exception {
@@ -337,14 +337,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, FOURTYTWO);
         Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
 
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, FOURTYTWO);
-        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO);
-        org.testng.Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, FOURTYTWO);
-        org.testng.Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        assertNotEquals(i, FOURTYTWO);
+        assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        assertEquals(i, FOURTYTWO);
+        assertEquals(i, FOURTYTWO, "Failure message to keep");
+        assertNotEquals(i, FOURTYTWO);
+        assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        assertEquals(i, FOURTYTWO);
+        assertEquals(i, FOURTYTWO, "Failure message to keep");
     }
 
     public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
@@ -357,14 +357,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, expected);
         Assert.assertEquals(i, expected, "Failure message to keep");
 
-        org.testng.Assert.assertNotEquals(i, expected);
-        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expected);
-        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, expected);
-        org.testng.Assert.assertNotEquals(i, expected, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expected);
-        org.testng.Assert.assertEquals(i, expected, "Failure message to keep");
+        assertNotEquals(i, expected);
+        assertNotEquals(i, expected, "Failure message to keep");
+        assertEquals(i, expected);
+        assertEquals(i, expected, "Failure message to keep");
+        assertNotEquals(i, expected);
+        assertNotEquals(i, expected, "Failure message to keep");
+        assertEquals(i, expected);
+        assertEquals(i, expected, "Failure message to keep");
     }
 
     public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
@@ -377,14 +377,14 @@ public class TestNGAssertSample {
         Assert.assertEquals(i, expectedI);
         Assert.assertEquals(i, expectedI, "Failure message to keep");
 
-        org.testng.Assert.assertNotEquals(i, expectedI);
-        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expectedI);
-        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
-        org.testng.Assert.assertNotEquals(i, expectedI);
-        org.testng.Assert.assertNotEquals(i, expectedI, "Failure message to keep");
-        org.testng.Assert.assertEquals(i, expectedI);
-        org.testng.Assert.assertEquals(i, expectedI, "Failure message to keep");
+        assertNotEquals(i, expectedI);
+        assertNotEquals(i, expectedI, "Failure message to keep");
+        assertEquals(i, expectedI);
+        assertEquals(i, expectedI, "Failure message to keep");
+        assertNotEquals(i, expectedI);
+        assertNotEquals(i, expectedI, "Failure message to keep");
+        assertEquals(i, expectedI);
+        assertEquals(i, expectedI, "Failure message to keep");
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/TestNGAssertSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/TestNGAssertSample.java
@@ -2,6 +2,7 @@
  * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
  *
  * Copyright (C) 2015 Jean-Noël Rouvignac - initial API and implementation
+ * Copyright (C) 2016 Fabrice Tiercelin - include more cases
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,11 +26,15 @@
  */
 package org.autorefactor.refactoring.rules.samples_out;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 import static org.testng.Assert.*;
 
 import org.testng.Assert;
 
 public class TestNGAssertSample {
+
+    private static final int FOURTYTWO = 42;
 
     public void shouldRefactorWithPrimitives(int i1, int i2) throws Exception {
         Assert.assertEquals(i1, i2);
@@ -182,7 +187,7 @@ public class TestNGAssertSample {
         assertNotNull(o, "Failure message to keep");
     }
 
-    public void shouldMoveConstantAsExpectedArgInWithEquals(Object o) throws Exception {
+    public void shouldMoveLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
         Assert.assertEquals(o, 42);
         Assert.assertEquals(o, 42, "Failure message to keep");
         Assert.assertNotEquals(o, 42);
@@ -192,6 +197,42 @@ public class TestNGAssertSample {
         assertEquals(o, 42, "Failure message to keep");
         assertNotEquals(o, 42);
         assertNotEquals(o, 42, "Failure message to keep");
+    }
+
+    public void doNotRefactorLiteralAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(o, 42);
+        Assert.assertEquals(o, 42, "Failure message to keep");
+        Assert.assertNotEquals(o, 42);
+        Assert.assertNotEquals(o, 42, "Failure message to keep");
+
+        assertEquals(o, 42);
+        assertEquals(o, 42, "Failure message to keep");
+        assertNotEquals(o, 42);
+        assertNotEquals(o, 42, "Failure message to keep");
+    }
+
+    public void shouldMoveConstantAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(o, FOURTYTWO);
+        Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
+        Assert.assertNotEquals(o, FOURTYTWO);
+        Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+
+        assertEquals(o, FOURTYTWO);
+        assertEquals(o, FOURTYTWO, "Failure message to keep");
+        assertNotEquals(o, FOURTYTWO);
+        assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+    }
+
+    public void doNotRefactorConstantAsExpectedArgInWithEquals(Object o) throws Exception {
+        Assert.assertEquals(o, FOURTYTWO);
+        Assert.assertEquals(o, FOURTYTWO, "Failure message to keep");
+        Assert.assertNotEquals(o, FOURTYTWO);
+        Assert.assertNotEquals(o, FOURTYTWO, "Failure message to keep");
+
+        assertEquals(o, FOURTYTWO);
+        assertEquals(o, FOURTYTWO, "Failure message to keep");
+        assertNotEquals(o, FOURTYTWO);
+        assertNotEquals(o, FOURTYTWO, "Failure message to keep");
     }
 
     public void shouldMoveExpectedVariableAsExpectedArgWithEquals(Object o, int expected) throws Exception {
@@ -264,6 +305,86 @@ public class TestNGAssertSample {
         assertNotEquals(o1, o2, "Failure message to keep");
         assertEquals(o1, o2);
         assertEquals(o1, o2, "Failure message to keep");
+    }
+
+    public void shouldRefactorIfLiteralThenFail(int i) throws Exception {
+        Assert.assertNotEquals(i, 42);
+        Assert.assertNotEquals(i, 42, "Failure message to keep");
+        Assert.assertEquals(i, 42);
+        Assert.assertEquals(i, 42, "Failure message to keep");
+        Assert.assertNotEquals(i, 42);
+        Assert.assertNotEquals(i, 42, "Failure message to keep");
+        Assert.assertEquals(i, 42);
+        Assert.assertEquals(i, 42, "Failure message to keep");
+
+        assertNotEquals(i, 42);
+        assertNotEquals(i, 42, "Failure message to keep");
+        assertEquals(i, 42);
+        assertEquals(i, 42, "Failure message to keep");
+        assertNotEquals(i, 42);
+        assertNotEquals(i, 42, "Failure message to keep");
+        assertEquals(i, 42);
+        assertEquals(i, 42, "Failure message to keep");
+    }
+
+    public void shouldRefactorIfConstantThenFail(int i) throws Exception {
+        Assert.assertNotEquals(i, FOURTYTWO);
+        Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        Assert.assertEquals(i, FOURTYTWO);
+        Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+        Assert.assertNotEquals(i, FOURTYTWO);
+        Assert.assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        Assert.assertEquals(i, FOURTYTWO);
+        Assert.assertEquals(i, FOURTYTWO, "Failure message to keep");
+
+        assertNotEquals(i, FOURTYTWO);
+        assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        assertEquals(i, FOURTYTWO);
+        assertEquals(i, FOURTYTWO, "Failure message to keep");
+        assertNotEquals(i, FOURTYTWO);
+        assertNotEquals(i, FOURTYTWO, "Failure message to keep");
+        assertEquals(i, FOURTYTWO);
+        assertEquals(i, FOURTYTWO, "Failure message to keep");
+    }
+
+    public void shouldRefactorIfExpectedThenFail(int i, int expected) throws Exception {
+        Assert.assertNotEquals(i, expected);
+        Assert.assertNotEquals(i, expected, "Failure message to keep");
+        Assert.assertEquals(i, expected);
+        Assert.assertEquals(i, expected, "Failure message to keep");
+        Assert.assertNotEquals(i, expected);
+        Assert.assertNotEquals(i, expected, "Failure message to keep");
+        Assert.assertEquals(i, expected);
+        Assert.assertEquals(i, expected, "Failure message to keep");
+
+        assertNotEquals(i, expected);
+        assertNotEquals(i, expected, "Failure message to keep");
+        assertEquals(i, expected);
+        assertEquals(i, expected, "Failure message to keep");
+        assertNotEquals(i, expected);
+        assertNotEquals(i, expected, "Failure message to keep");
+        assertEquals(i, expected);
+        assertEquals(i, expected, "Failure message to keep");
+    }
+
+    public void shouldRefactorIfNearlyExpectedThenFail(int i, int expectedI) throws Exception {
+        Assert.assertNotEquals(i, expectedI);
+        Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        Assert.assertEquals(i, expectedI);
+        Assert.assertEquals(i, expectedI, "Failure message to keep");
+        Assert.assertNotEquals(i, expectedI);
+        Assert.assertNotEquals(i, expectedI, "Failure message to keep");
+        Assert.assertEquals(i, expectedI);
+        Assert.assertEquals(i, expectedI, "Failure message to keep");
+
+        assertNotEquals(i, expectedI);
+        assertNotEquals(i, expectedI, "Failure message to keep");
+        assertEquals(i, expectedI);
+        assertEquals(i, expectedI, "Failure message to keep");
+        assertNotEquals(i, expectedI);
+        assertNotEquals(i, expectedI, "Failure message to keep");
+        assertEquals(i, expectedI);
+        assertEquals(i, expectedI, "Failure message to keep");
     }
 
     public void doNotRefactorBecauseOfElseStatement(int i1, int i2, Object o1) throws Exception {


### PR DESCRIPTION
This PR reuses the code for TestNG and applies it to JUnit. It handles `junit.framework.*`, `org.junit.*`, merge codes and generalizes the expected detection.