### PR TITLE
S1157 case insensitive string comparisons should be made without intermediate upper or lower casing

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/StringRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/StringRefactoring.java
@@ -45,7 +45,8 @@ public class StringRefactoring extends AbstractRefactoringRule {
             + "Removes:\n"
             + "- creating a String instance from a String constant or literal,\n"
             + "- calling String.toString() on a String instance,\n"
-            + "- remove calls to String.toString() inside String concatenations.";
+            + "- remove calls to String.toString() inside String concatenations,\n"
+            + "- replace forced string tranformation by String.valueOf().";
     }
 
     @Override

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringSample.java
@@ -200,4 +200,33 @@ public class StringSample {
     public void doNotReplaceConcatenateWithCharArray(char[] chars) {
         String text = "" + chars;
     }
+
+    public void replaceCaseShift(String s1, String s2) {
+        s1.toUpperCase().equals(s2.toUpperCase());
+        s1.toLowerCase().equals(s2.toLowerCase());
+        "lorem".toUpperCase().equals("ipsum".toUpperCase());
+        "lorem".toLowerCase().equals("ipsum".toLowerCase());
+    }
+
+    public void doNotReplaceUnilateralCaseShift(String s1, String s2) {
+        s1.toUpperCase().equals(s2);
+        s1.toLowerCase().equals(s2);
+        s1.equals(s2.toLowerCase());
+        s1.equals(s2.toUpperCase());
+    }
+
+    public void doNotReplaceCaseIncompatibility(String s1, String s2) {
+        s1.toLowerCase().equals(s2.toUpperCase());
+    }
+
+    public void simplifyInsensitiveCaseEquality(String s1, String s2) {
+        s1.toUpperCase().equalsIgnoreCase(s2.toUpperCase());
+        s1.toLowerCase().equalsIgnoreCase(s2.toLowerCase());
+        s1.toUpperCase().equalsIgnoreCase(s2.toLowerCase());
+        s1.toLowerCase().equalsIgnoreCase(s2.toUpperCase());
+        s1.toUpperCase().equalsIgnoreCase(s2);
+        s1.toLowerCase().equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2.toLowerCase());
+        s1.equalsIgnoreCase(s2.toUpperCase());
+    }
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringSample.java
@@ -200,4 +200,33 @@ public class StringSample {
     public void doNotReplaceConcatenateWithCharArray(char[] chars) {
         String text = "" + chars;
     }
+
+    public void replaceCaseShift(String s1, String s2) {
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        "lorem".equalsIgnoreCase("ipsum");
+        "lorem".equalsIgnoreCase("ipsum");
+    }
+
+    public void doNotReplaceUnilateralCaseShift(String s1, String s2) {
+        s1.toUpperCase().equals(s2);
+        s1.toLowerCase().equals(s2);
+        s1.equals(s2.toLowerCase());
+        s1.equals(s2.toUpperCase());
+    }
+
+    public void doNotReplaceCaseIncompatibility(String s1, String s2) {
+        s1.toLowerCase().equals(s2.toUpperCase());
+    }
+
+    public void simplifyInsensitiveCaseEquality(String s1, String s2) {
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+        s1.equalsIgnoreCase(s2);
+    }
 }


### PR DESCRIPTION
### **Given**
```Java
"lorem".toLowerCase().equals("ipsum".toLowerCase());
```

### **When**
Refactor.

### **Then**
```Java
"lorem".equalsIgnoreCase("ipsum");
```

This PR implements a quickfix for the SonarQube alert [S1157: case insensitive string comparisons should be made without intermediate upper or lower casing](https://dev.eclipse.org/sonar/rules/show/squid:S1157).