### PR TITLE
Don't take an int for a character. Closes #172 and #238

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/ASTBuilder.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/ASTBuilder.java
@@ -245,7 +245,7 @@ public class ASTBuilder {
     public CastExpression cast(Type type, Expression expr) {
         final CastExpression ce = ast.newCastExpression();
         ce.setType(type);
-        ce.setExpression(expr);
+        ce.setExpression(parenthesizeIfNeeded(expr));
         return ce;
     }
 

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/StringBuilderRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/StringBuilderRefactoring.java
@@ -324,13 +324,15 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
     }
 
     private Pair<ITypeBinding, Expression> getTypeAndValue(final MethodInvocation mi) {
+        final ITypeBinding expectedType = mi.resolveMethodBinding().getParameterTypes()[0];
+        final ITypeBinding actualType = arg0(mi).resolveTypeBinding();
+
         ITypeBinding otherType = null;
-        ITypeBinding expectedType = mi.resolveMethodBinding().getParameterTypes()[0];
-        ITypeBinding actualType = arg0(mi).resolveTypeBinding();
         if (!expectedType.equals(actualType)
                 && !Bindings.getBoxedTypeBinding(expectedType, mi.getAST()).equals(actualType)) {
-            otherType = mi.resolveMethodBinding().getParameterTypes()[0];
+            otherType = expectedType;
         }
+
         return Pair.<ITypeBinding, Expression>of(otherType, arg0(mi));
     }
 
@@ -338,7 +340,7 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         Expression expression = null;
         if (typeAndValue.getFirst() != null) {
             expression = b.cast(b.type(typeAndValue.getFirst().getQualifiedName()),
-                    b.parenthesizeIfNeeded(b.copy(typeAndValue.getSecond())));
+                    b.copy(typeAndValue.getSecond()));
         } else if (typeAndValue.getFirst() == null)  {
             expression = b.copy(typeAndValue.getSecond());
         }

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/StringBuilderRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/StringBuilderRefactoring.java
@@ -27,7 +27,6 @@
 package org.autorefactor.refactoring.rules;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -36,10 +35,12 @@ import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.autorefactor.refactoring.ASTBuilder;
+import org.autorefactor.util.Pair;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
 import org.eclipse.jdt.core.dom.MethodInvocation;
@@ -91,7 +92,8 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         // String s = "" + Integer.toString(1);
         // String s = "" + Long.toString(1);
         if (isStringConcat(node)) {
-            final LinkedList<Expression> allOperands = new LinkedList<Expression>();
+            final LinkedList<Pair<ITypeBinding, Expression>> allOperands =
+                    new LinkedList<Pair<ITypeBinding, Expression>>();
             addAllSubExpressions(node, allOperands, null);
             boolean replaceNeeded = filterOutEmptyStringsFromStringConcat(allOperands);
             if (replaceNeeded) {
@@ -109,19 +111,19 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         return VISIT_SUBTREE;
     }
 
-    private boolean filterOutEmptyStringsFromStringConcat(List<Expression> allOperands) {
+    private boolean filterOutEmptyStringsFromStringConcat(List<Pair<ITypeBinding, Expression>> allOperands) {
         boolean replaceNeeded = false;
         boolean canRemoveEmptyStrings = false;
         for (int i = 0; i < allOperands.size(); i++) {
-            Expression expr = allOperands.get(i);
-            boolean canNowRemoveEmptyStrings = canRemoveEmptyStrings || hasType(expr, "java.lang.String");
-            if (isEmptyString(expr)) {
+            Pair<ITypeBinding, Expression> expr = allOperands.get(i);
+            boolean canNowRemoveEmptyStrings = canRemoveEmptyStrings || hasType(expr.getSecond(), "java.lang.String");
+            if (isEmptyString(expr.getSecond())) {
                 boolean removeExpr = false;
                 if (canRemoveEmptyStrings) {
                     removeExpr = true;
                 } else if (canNowRemoveEmptyStrings
                         && i + 1 < allOperands.size()
-                        && hasType(allOperands.get(i + 1), "java.lang.String")) {
+                        && hasType(allOperands.get(i + 1).getSecond(), "java.lang.String")) {
                     removeExpr = true;
                 }
 
@@ -145,63 +147,88 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
 
     @Override
     public boolean visit(MethodInvocation node) {
-        if (node.getExpression() == null) {
-            return VISIT_SUBTREE;
-        }
-        if ("append".equals(node.getName().getIdentifier())
+        if (node.getExpression() != null
+                && "append".equals(node.getName().getIdentifier())
                 && arguments(node).size() == 1
-                // most expensive check comes last
+                // Most expensive check comes last
                 && isStringBuilderOrBuffer(node.getExpression())) {
-            final LinkedList<Expression> allAppendedStrings = new LinkedList<Expression>();
+            final MethodInvocation embeddedMI = as(arg0(node), MethodInvocation.class);
+
+            if (isMethod(embeddedMI, "java.lang.String", "substring", "int", "int")
+                    || isMethod(embeddedMI, "java.lang.CharSequence", "subSequence", "int", "int")) {
+                replaceWithAppendSubstring(node, embeddedMI);
+                return DO_NOT_VISIT_SUBTREE;
+            }
+
+            final LinkedList<Pair<ITypeBinding, Expression>> allAppendedStrings =
+                    new LinkedList<Pair<ITypeBinding, Expression>>();
             final AtomicBoolean hasStringConcat = new AtomicBoolean(false);
             final Expression lastExpr = collectAllAppendedStrings(node, allAppendedStrings, hasStringConcat);
-            if ((lastExpr instanceof Name || lastExpr instanceof FieldAccess)
-                    && isRewriteNeeded(allAppendedStrings, hasStringConcat)) {
+
+            if (simplifyAppending(allAppendedStrings, hasStringConcat.get())) {
                 if (allAppendedStrings.isEmpty()
                         && isVariable(node.getExpression())
                         && node.getParent() instanceof Statement) {
                     ctx.getRefactorings().remove(node.getParent());
                 } else {
-                    // rewrite the successive calls to append()
-                    ctx.getRefactorings().replace(node,
-                            createStringAppends(lastExpr, allAppendedStrings));
+                    replaceWithNewStringAppends(node, allAppendedStrings, lastExpr);
                 }
-                return DO_NOT_VISIT_SUBTREE;
-            }
-
-            final MethodInvocation embeddedMI = as(allAppendedStrings, MethodInvocation.class);
-            if (isStringValueOf(embeddedMI)
-                    && isStringBuilderOrBuffer(node.getExpression())) {
-                final Expression arg0 = arg0(embeddedMI);
-                this.ctx.getRefactorings().replace(node,
-                        createStringAppends(lastExpr, Arrays.asList(arg0)));
-                return DO_NOT_VISIT_SUBTREE;
-            }
-            if (isMethod(embeddedMI, "java.lang.String", "substring", "int", "int")
-                    || isMethod(embeddedMI, "java.lang.CharSequence", "subSequence", "int", "int")) {
-                final ASTBuilder b = this.ctx.getASTBuilder();
-                final Expression stringVar = b.copy(embeddedMI.getExpression());
-                final List<Expression> args = arguments(embeddedMI);
-                final Expression arg0 = b.copy(args.get(0));
-                final Expression arg1 = b.copy(args.get(1));
-                this.ctx.getRefactorings().replace(node,
-                        createAppendSubstring(b, b.copy(lastExpr), stringVar, arg0, arg1));
                 return DO_NOT_VISIT_SUBTREE;
             }
         } else if (isMethod(node, "java.lang.StringBuilder", "toString")
                 || isMethod(node, "java.lang.StringBuffer", "toString")) {
-            final LinkedList<Expression> allAppendedStrings = new LinkedList<Expression>();
+            final LinkedList<Pair<ITypeBinding, Expression>> allAppendedStrings =
+                    new LinkedList<Pair<ITypeBinding, Expression>>();
             final Expression lastExpr = collectAllAppendedStrings(node.getExpression(), allAppendedStrings, null);
             // TODO new StringBuffer().append(" bla").append("bla").toString();
             // outputs " blabla"
             if (lastExpr instanceof ClassInstanceCreation) {
-                // replace with String concatenation
+                // Replace with String concatenation
                 this.ctx.getRefactorings().replace(node,
                         createStringConcats(allAppendedStrings));
                 return DO_NOT_VISIT_SUBTREE;
             }
         }
         return VISIT_SUBTREE;
+    }
+
+    /**
+     * Rewrite the successive calls to append()
+     *
+     * @param node The node to replace.
+     * @param allAppendedStrings All appended strings.
+     * @param lastExpr The expression on which the methods are called.
+     */
+    private void replaceWithNewStringAppends(MethodInvocation node,
+            final LinkedList<Pair<ITypeBinding, Expression>> allAppendedStrings, final Expression lastExpr) {
+        final ASTBuilder b = this.ctx.getASTBuilder();
+        Expression result = b.copy(lastExpr);
+        for (Pair<ITypeBinding, Expression> typeAndValue : allAppendedStrings) {
+            if (result == null) {
+                result = b.copy(typeAndValue.getSecond());
+            } else {
+                result = b.invoke(result, "append", getTypedExpression(b, typeAndValue));
+            }
+        }
+        ctx.getRefactorings().replace(node, result);
+    }
+
+    private void replaceWithAppendSubstring(final MethodInvocation node, final MethodInvocation embeddedMI) {
+        final ASTBuilder b = this.ctx.getASTBuilder();
+        final Expression stringVar = b.copy(embeddedMI.getExpression());
+        final List<Expression> args = arguments(embeddedMI);
+        final Expression arg0 = b.copy(args.get(0));
+        final Expression arg1 = b.copy(args.get(1));
+        final Expression lastExpr = b.copy(node.getExpression());
+        MethodInvocation newAppendSubstring = null;
+        if (arg1 == null) {
+            newAppendSubstring = b.invoke(lastExpr, "append", stringVar, arg0);
+        } else {
+            newAppendSubstring = b.invoke(lastExpr, "append", stringVar, arg0, arg1);
+        }
+
+        this.ctx.getRefactorings().replace(node,
+                newAppendSubstring);
     }
 
     private boolean isStringBuilderOrBuffer(final Expression expr) {
@@ -220,25 +247,25 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         }
     }
 
-    private MethodInvocation createAppendSubstring(ASTBuilder b, Expression lastExpr,
-            Expression stringVar, Expression substringArg0, Expression substringArg1) {
-        if (substringArg1 == null) {
-            return b.invoke(lastExpr, "append", stringVar, substringArg0);
-        }
-        return b.invoke(lastExpr, "append", stringVar, substringArg0, substringArg1);
+    /**
+     * Simplify an appending chain.
+     *
+     * @param allAppendedStrings All appended strings
+     * @param hasStringConcat True if has string concatenation
+     * @return True if rewrite is needed
+     */
+    private boolean simplifyAppending(final LinkedList<Pair<ITypeBinding, Expression>> allAppendedStrings,
+            final boolean hasStringConcat) {
+        final boolean needRefactor1 = filterOutEmptyStrings(allAppendedStrings);
+        final boolean needRefactor2 = removeCallsToToString(allAppendedStrings);
+        return needRefactor1 || needRefactor2 || hasStringConcat;
     }
 
-    private boolean isRewriteNeeded(final LinkedList<Expression> allAppendedStrings, AtomicBoolean hasStringConcat) {
-        final boolean res1 = filterOutEmptyStrings(allAppendedStrings);
-        final boolean res2 = removeCallsToToString(allAppendedStrings);
-        return res1 || res2 || hasStringConcat.get();
-    }
-
-    private boolean filterOutEmptyStrings(List<Expression> allExprs) {
+    private boolean filterOutEmptyStrings(final List<Pair<ITypeBinding, Expression>> allExprs) {
         boolean result = false;
-        for (Iterator<Expression> iter = allExprs.iterator(); iter.hasNext();) {
-            Expression expr = iter.next();
-            if (isEmptyString(expr)) {
+        for (Iterator<Pair<ITypeBinding, Expression>> iter = allExprs.iterator(); iter.hasNext();) {
+            Pair<ITypeBinding, Expression> expr = iter.next();
+            if (expr.getFirst() == null && isEmptyString(expr.getSecond())) {
                 iter.remove();
                 result = true;
             }
@@ -246,28 +273,21 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         return result;
     }
 
-    private boolean removeCallsToToString(List<Expression> allExprs) {
+    private boolean removeCallsToToString(final List<Pair<ITypeBinding, Expression>> allExprs) {
         boolean result = false;
-        for (ListIterator<Expression> iter = allExprs.listIterator(); iter.hasNext();) {
-            final Expression expr = iter.next();
-            if (expr.getNodeType() == ASTNode.METHOD_INVOCATION) {
-                final MethodInvocation mi = (MethodInvocation) expr;
+        for (ListIterator<Pair<ITypeBinding, Expression>> iter = allExprs.listIterator(); iter.hasNext();) {
+            final Pair<ITypeBinding, Expression> expr = iter.next();
+            if (expr.getSecond().getNodeType() == ASTNode.METHOD_INVOCATION) {
+                final MethodInvocation mi = (MethodInvocation) expr.getSecond();
                 if (isMethod(mi, "java.lang.Object", "toString")) {
                     if (mi.getExpression() != null) {
-                        iter.set(mi.getExpression());
+                        iter.set(Pair.<ITypeBinding, Expression>of(null, mi.getExpression()));
                     } else {
-                        iter.set(this.ctx.getAST().newThisExpression());
+                        iter.set(Pair.<ITypeBinding, Expression>of(null, this.ctx.getAST().newThisExpression()));
                     }
                     result = true;
-                } else if (isMethod(mi, "java.lang.Boolean", "toString", "boolean")
-                        || isMethod(mi, "java.lang.Byte", "toString", "byte")
-                        || isMethod(mi, "java.lang.Character", "toString", "char")
-                        || isMethod(mi, "java.lang.Short", "toString", "short")
-                        || isMethod(mi, "java.lang.Integer", "toString", "int")
-                        || isMethod(mi, "java.lang.Long", "toString", "long")
-                        || isMethod(mi, "java.lang.Float", "toString", "float")
-                        || isMethod(mi, "java.lang.Double", "toString", "double")) {
-                    iter.set(arg0(mi));
+                } else if (isToString(mi) || isStringValueOf(mi)) {
+                    iter.set(getTypeAndValue(mi));
                     result = true;
                 }
             }
@@ -275,7 +295,18 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         return result;
     }
 
-    private boolean isStringValueOf(MethodInvocation mi) {
+    private boolean isToString(final MethodInvocation mi) {
+        return isMethod(mi, "java.lang.Boolean", "toString", "boolean")
+                || isMethod(mi, "java.lang.Byte", "toString", "byte")
+                || isMethod(mi, "java.lang.Character", "toString", "char")
+                || isMethod(mi, "java.lang.Short", "toString", "short")
+                || isMethod(mi, "java.lang.Integer", "toString", "int")
+                || isMethod(mi, "java.lang.Long", "toString", "long")
+                || isMethod(mi, "java.lang.Float", "toString", "float")
+                || isMethod(mi, "java.lang.Double", "toString", "double");
+    }
+
+    private boolean isStringValueOf(final MethodInvocation mi) {
         return isMethod(mi, "java.lang.String", "valueOf", "java.lang.Object")
                 || isMethod(mi, "java.lang.String", "valueOf", "boolean")
                 || isMethod(mi, "java.lang.Boolean", "valueOf", "boolean")
@@ -291,52 +322,62 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
                 || isMethod(mi, "java.lang.Double", "valueOf", "double");
     }
 
-    private ASTNode createStringAppends(Expression lastExpr, List<Expression> appendedStrings) {
-        final ASTBuilder b = this.ctx.getASTBuilder();
-        Expression result = b.copy(lastExpr);
-        for (Expression expr : appendedStrings) {
-            if (result == null) {
-                result = b.copy(expr);
-            } else {
-                result = b.invoke(result, "append", b.copy(expr));
-            }
+    private Pair<ITypeBinding, Expression> getTypeAndValue(final MethodInvocation mi) {
+        ITypeBinding otherType = null;
+        if (!mi.resolveMethodBinding().getParameterTypes()[0].equals(arg0(mi).resolveTypeBinding())) {
+            otherType = mi.resolveMethodBinding().getParameterTypes()[0];
         }
-        return result;
+        return Pair.<ITypeBinding, Expression>of(otherType, arg0(mi));
     }
 
-    private Expression createStringConcats(List<Expression> appendedStrings) {
+    private Expression getTypedExpression(final ASTBuilder b, final Pair<ITypeBinding, Expression> typeAndValue) {
+        Expression expression = null;
+        if (typeAndValue.getFirst() != null) {
+//            expression = b.cast(b.toType(typeAndValue.getFirst(),
+//                    new TypeNameDecider(b.copy(typeAndValue.getSecond()))),
+//                    b.copy(typeAndValue.getSecond()));
+            expression = b.cast(b.type(typeAndValue.getFirst().getQualifiedName()),
+                    b.parenthesizeIfNeeded(b.copy(typeAndValue.getSecond())));
+        } else if (typeAndValue.getFirst() == null)  {
+            expression = b.copy(typeAndValue.getSecond());
+        }
+        return expression;
+    }
+
+    private Expression createStringConcats(List<Pair<ITypeBinding, Expression>> appendedStrings) {
         final ASTBuilder b = this.ctx.getASTBuilder();
         switch (appendedStrings.size()) {
         case 0:
             return b.string("");
 
         case 1:
-            final Expression expr = appendedStrings.get(0);
-            if (hasType(expr, "java.lang.String")) {
-                return b.copy(expr);
+            final Pair<ITypeBinding, Expression> expr = appendedStrings.get(0);
+            if (hasType(expr.getSecond(), "java.lang.String")) {
+                return b.copy(expr.getSecond());
             }
-            return b.invoke("String", "valueOf", b.copy(expr));
+            return b.invoke("String", "valueOf", getTypedExpression(b, expr));
 
         default: // >== 2
-            final Expression arg0 = appendedStrings.get(0);
-            final Expression arg1 = appendedStrings.get(1);
-            boolean prependEmptyString = !hasType(arg0, "java.lang.String")
-                    && !hasType(arg1, "java.lang.String");
+            final Pair<ITypeBinding, Expression> arg0 = appendedStrings.get(0);
+            final Pair<ITypeBinding, Expression> arg1 = appendedStrings.get(1);
 
-            for (ListIterator<Expression> it = appendedStrings.listIterator(); it.hasNext();) {
-                final Expression e = it.next();
-                it.set(b.parenthesizeIfNeeded(b.copy(e)));
-            }
+            List<Expression> concatenateStrings = new ArrayList<Expression>(appendedStrings.size());
+            boolean prependEmptyString = !hasType(arg0.getSecond(), "java.lang.String")
+                    && !hasType(arg1.getSecond(), "java.lang.String");
 
             if (prependEmptyString) {
-                appendedStrings.add(0, b.string(""));
+                concatenateStrings.add(b.string(""));
             }
-            return b.infixExpr(Operator.PLUS, appendedStrings);
+
+            for (final Pair<ITypeBinding, Expression> typeAndValue : appendedStrings) {
+                concatenateStrings.add(b.parenthesizeIfNeeded(getTypedExpression(b, typeAndValue)));
+            }
+            return b.infixExpr(Operator.PLUS, concatenateStrings);
         }
     }
 
     private Expression collectAllAppendedStrings(Expression expr,
-            final LinkedList<Expression> allOperands, AtomicBoolean hasStringConcat) {
+            final LinkedList<Pair<ITypeBinding, Expression>> allOperands, AtomicBoolean hasStringConcat) {
         final Expression exp = removeParentheses(expr);
         if (isStringBuilderOrBuffer(exp)) {
             if (exp instanceof MethodInvocation) {
@@ -354,7 +395,7 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
                     if (isStringBuilderOrBuffer(cic)
                         && (hasType(arg0, "java.lang.String")
                                 || instanceOf(arg0, "java.lang.CharSequence"))) {
-                        allOperands.addFirst(arg0);
+                        allOperands.addFirst(Pair.<ITypeBinding, Expression>of(null, arg0));
                     }
                 }
                 return cic;
@@ -365,7 +406,7 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
         return null;
     }
 
-    private void addAllSubExpressions(final Expression arg, final LinkedList<Expression> results,
+    private void addAllSubExpressions(final Expression arg, final LinkedList<Pair<ITypeBinding, Expression>> results,
             final AtomicBoolean hasStringConcat) {
         if (arg instanceof InfixExpression) {
             final InfixExpression ie = (InfixExpression) arg;
@@ -385,7 +426,7 @@ public class StringBuilderRefactoring extends AbstractRefactoringRule {
                 return;
             }
         }
-        results.addFirst(arg);
+        results.addFirst(Pair.<ITypeBinding, Expression>of(null, arg));
     }
 
     private boolean isStringConcat(InfixExpression node) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringBuilderSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringBuilderSample.java
@@ -84,6 +84,11 @@ public class StringBuilderSample {
         sb.append(Float.valueOf(f));
         sb.append(String.valueOf(d));
         sb.append(Double.valueOf(d));
+
+        sb.append(String.valueOf(o)).append(String.valueOf(b)).append(Boolean.valueOf(b)).append(String.valueOf(c))
+                .append(Character.valueOf(c)).append(String.valueOf(i)).append(Integer.valueOf(i))
+                .append(String.valueOf(l)).append(Long.valueOf(l)).append(String.valueOf(f)).append(Float.valueOf(f))
+                .append(String.valueOf(d)).append(Double.valueOf(d));
     }
 
     public void removeUselessCallsToValueOfWithStringBufferAppend(
@@ -102,6 +107,11 @@ public class StringBuilderSample {
         sb.append(Float.valueOf(f));
         sb.append(String.valueOf(d));
         sb.append(Double.valueOf(d));
+
+        sb.append(String.valueOf(o)).append(String.valueOf(b)).append(Boolean.valueOf(b)).append(String.valueOf(c))
+                .append(Character.valueOf(c)).append(String.valueOf(i)).append(Integer.valueOf(i))
+                .append(String.valueOf(l)).append(Long.valueOf(l)).append(String.valueOf(f)).append(Float.valueOf(f))
+                .append(String.valueOf(d)).append(Double.valueOf(d));
     }
 
     public void removeUselessCallsToToStringOfWithStringBuilderAppend(
@@ -117,6 +127,10 @@ public class StringBuilderSample {
         sb.append(Long.toString(l));
         sb.append(Float.toString(f));
         sb.append(Double.toString(d));
+
+        sb.append(toString()).append(o.toString()).append(Boolean.toString(bo)).append(Byte.toString(by))
+                .append(Character.toString(c)).append(Short.toString(s)).append(Integer.toString(i))
+                .append(Long.toString(l)).append(Float.toString(f)).append(Double.toString(d));
     }
 
     public void removeUselessCallsToToStringOfWithStringBufferAppend(
@@ -132,6 +146,17 @@ public class StringBuilderSample {
         sb.append(Long.toString(l));
         sb.append(Float.toString(f));
         sb.append(Double.toString(d));
+
+        sb.append(toString()).append(o.toString()).append(Boolean.toString(bo)).append(Byte.toString(by))
+                .append(Character.toString(c)).append(Short.toString(s)).append(Integer.toString(i))
+                .append(Long.toString(l)).append(Float.toString(f)).append(Double.toString(d));
+    }
+
+    public void removeValueOfCallsWithCast(
+        char c, byte b, int i) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Integer.valueOf(b));
+        sb.append(Integer.valueOf(c));
     }
 
     public void removeSubstringDoubleArgsCallsWithAppend(String s) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringBuilderSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringBuilderSample.java
@@ -152,11 +152,18 @@ public class StringBuilderSample {
                 .append(Long.toString(l)).append(Float.toString(f)).append(Double.toString(d));
     }
 
-    public void removeValueOfCallsWithCast(
-        char c, byte b, int i) {
+    public void removeValueOfCallsWithCast(char c, byte b, Character cObject, Byte bObject) {
         StringBuilder sb = new StringBuilder();
         sb.append(Integer.valueOf(b));
         sb.append(Integer.valueOf(c));
+        sb.append(Integer.valueOf(bObject));
+        sb.append(Integer.valueOf(cObject));
+    }
+
+    public void removeValueOfCallsWithoutCast(int i, Integer iObject) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(Integer.valueOf(i));
+        sb.append(Integer.valueOf(iObject));
     }
 
     public void removeSubstringDoubleArgsCallsWithAppend(String s) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/StringSample.java
@@ -88,7 +88,10 @@ public class StringSample {
         String s6 = Long.toString(42l) + " foo";
         String s7 = Float.toString(42.42f) + " foo";
         String s8 = Double.toString(42.42) + " foo";
-        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+
+        String s9 = Integer.toString('c') + " foo";
+        String s10 = Integer.toString(b) + " foo";
+        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
     }
 
     public String removeUselessToStringRightOperand(byte b, short s) {
@@ -100,7 +103,10 @@ public class StringSample {
         String s6 = "foo " + Long.toString(42l);
         String s7 = "foo " + Float.toString(42.42f);
         String s8 = "foo " + Double.toString(42.42);
-        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+
+        String s9 = "foo " + Integer.toString('c');
+        String s10 = "foo " + Integer.toString(b);
+        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
     }
 
     public String removeUselessToStringExtendedOperand(byte b, short s) {
@@ -112,7 +118,10 @@ public class StringSample {
         String s6 = "foo " + Long.toString(42l) + " bar";
         String s7 = "foo " + Float.toString(42.42f) + " bar";
         String s8 = "foo " + Double.toString(42.42) + " bar";
-        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+
+        String s9 = "foo " + Integer.toString('c') + " bar";
+        String s10 = "foo " + Integer.toString(b) + " bar";
+        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
     }
 
     public String removeUselessValueOfLeftOperand(byte b, short s) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringBuilderSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringBuilderSample.java
@@ -84,6 +84,10 @@ public class StringBuilderSample {
         sb.append(f);
         sb.append(d);
         sb.append(d);
+
+        sb.append(o).append(b).append(b).append(c).append(c).append(i)
+                .append(i).append(l).append(l).append(f).append(f).append(d)
+                .append(d);
     }
 
     public void removeUselessCallsToValueOfWithStringBufferAppend(
@@ -102,6 +106,10 @@ public class StringBuilderSample {
         sb.append(f);
         sb.append(d);
         sb.append(d);
+
+        sb.append(o).append(b).append(b).append(c).append(c).append(i)
+                .append(i).append(l).append(l).append(f).append(f).append(d)
+                .append(d);
     }
 
     public void removeUselessCallsToToStringOfWithStringBuilderAppend(
@@ -117,6 +125,9 @@ public class StringBuilderSample {
         sb.append(l);
         sb.append(f);
         sb.append(d);
+
+        sb.append(this).append(o).append(bo).append(by).append(c).append(s)
+                .append(i).append(l).append(f).append(d);
     }
 
     public void removeUselessCallsToToStringOfWithStringBufferAppend(
@@ -132,6 +143,16 @@ public class StringBuilderSample {
         sb.append(l);
         sb.append(f);
         sb.append(d);
+
+        sb.append(this).append(o).append(bo).append(by).append(c).append(s)
+                .append(i).append(l).append(f).append(d);
+    }
+
+    public void removeValueOfCallsWithCast(
+        char c, byte b, int i) {
+        StringBuilder sb = new StringBuilder();
+        sb.append((int) b);
+        sb.append((int) c);
     }
 
     public void removeSubstringDoubleArgsCallsWithAppend(String s) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringBuilderSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringBuilderSample.java
@@ -148,11 +148,18 @@ public class StringBuilderSample {
                 .append(i).append(l).append(f).append(d);
     }
 
-    public void removeValueOfCallsWithCast(
-        char c, byte b, int i) {
+    public void removeValueOfCallsWithCast(char c, byte b, Character cObject, Byte bObject) {
         StringBuilder sb = new StringBuilder();
         sb.append((int) b);
         sb.append((int) c);
+        sb.append((int) bObject);
+        sb.append((int) cObject);
+    }
+
+    public void removeValueOfCallsWithoutCast(int i, Integer iObject) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(i);
+        sb.append(iObject);
     }
 
     public void removeSubstringDoubleArgsCallsWithAppend(String s) {

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/StringSample.java
@@ -88,7 +88,10 @@ public class StringSample {
         String s6 = 42l + " foo";
         String s7 = 42.42f + " foo";
         String s8 = 42.42 + " foo";
-        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+
+        String s9 = (int) 'c' + " foo";
+        String s10 = (int) b + " foo";
+        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
     }
 
     public String removeUselessToStringRightOperand(byte b, short s) {
@@ -100,7 +103,10 @@ public class StringSample {
         String s6 = "foo " + 42l;
         String s7 = "foo " + 42.42f;
         String s8 = "foo " + 42.42;
-        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+
+        String s9 = "foo " + (int) 'c';
+        String s10 = "foo " + (int) b;
+        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
     }
 
     public String removeUselessToStringExtendedOperand(byte b, short s) {
@@ -112,14 +118,17 @@ public class StringSample {
         String s6 = "foo " + 42l + " bar";
         String s7 = "foo " + 42.42f + " bar";
         String s8 = "foo " + 42.42 + " bar";
-        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+
+        String s9 = "foo " + (int) 'c' + " bar";
+        String s10 = "foo " + (int) b + " bar";
+        return s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
     }
 
     public String removeUselessValueOfLeftOperand(byte b, short s) {
         String s1 = true + " foo";
         String s2 = 'c' + " foo";
-        String s3 = b + " foo";
-        String s4 = s + " foo";
+        String s3 = (int) b + " foo";
+        String s4 = (int) s + " foo";
         String s5 = 42 + " foo";
         String s6 = 42l + " foo";
         String s7 = 42.42f + " foo";
@@ -131,8 +140,8 @@ public class StringSample {
     public String removeUselessValueOfRightOperand(byte b, short s) {
         String s1 = "foo " + true;
         String s2 = "foo " + 'c';
-        String s3 = "foo " + b;
-        String s4 = "foo " + s;
+        String s3 = "foo " + (int) b;
+        String s4 = "foo " + (int) s;
         String s5 = "foo " + 42;
         String s6 = "foo " + 42l;
         String s7 = "foo " + 42.42f;
@@ -144,8 +153,8 @@ public class StringSample {
     public String removeUselessValueOfExtendedOperand(byte b, short s) {
         String s1 = "foo " + true + " bar";
         String s2 = "foo " + 'c' + " bar";
-        String s3 = "foo " + b + " bar";
-        String s4 = "foo " + s + " bar";
+        String s3 = "foo " + (int) b + " bar";
+        String s4 = "foo " + (int) s + " bar";
         String s5 = "foo " + 42 + " bar";
         String s6 = "foo " + 42l + " bar";
         String s7 = "foo " + 42.42f + " bar";


### PR DESCRIPTION
This PR:
- Fixes the missing int conversion for `StringBuilder`
- Fixes the missing int conversion for `String`
- Expands the refactoring for `StringBuilder`
- Also fixes #238 at the same time

Unfortunately, the use of `Bindings.getBoxedTypeBinding()` adds a warning. Perhaps you have an idea to avoid it.