### PR TITLE
Static class name elimination buggy. Closes #222

### DIFF
--- a/plugin/src/main/java/org/autorefactor/refactoring/ASTHelper.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/ASTHelper.java
@@ -2209,7 +2209,6 @@ public final class ASTHelper {
         final VariableDeclarationIdentifierVisitor visitor = new VariableDeclarationIdentifierVisitor(node,
                 includeInnerScopes);
         node.accept(visitor);
-
         return visitor.getVariableNames();
     }
 }

--- a/plugin/src/main/java/org/autorefactor/refactoring/ASTHelper.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/ASTHelper.java
@@ -197,9 +197,9 @@ public final class ASTHelper {
     }
 
     private static final class VariableDeclarationIdentifierVisitor extends ASTVisitor {
-        private Set<String> variableNames = new HashSet<String>();
-        private ASTNode startNode;
-        private boolean includeInnerScopes;
+        private final Set<String> variableNames = new HashSet<String>();
+        private final ASTNode startNode;
+        private final boolean includeInnerScopes;
 
         private Set<String> getVariableNames() {
             return variableNames;

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/ReplaceQualifiedNamesBySimpleNamesRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/ReplaceQualifiedNamesBySimpleNamesRefactoring.java
@@ -655,12 +655,14 @@ public class ReplaceQualifiedNamesBySimpleNamesRefactoring extends AbstractRefac
     }
 
     private boolean processNode(final ASTNode node, final Set<String> localIdentifiers) {
-        final QualifiedNamesVisitor visitor = new QualifiedNamesVisitor();
-        node.accept(visitor);
+        if (node != null) {
+            final QualifiedNamesVisitor visitor = new QualifiedNamesVisitor();
+            node.accept(visitor);
 
-        for (final QualifiedName qualifiedNameToProcess : visitor.getQualifiedNamesToProcess()) {
-            if (maybeReplaceFqnWithSimpleName(qualifiedNameToProcess, localIdentifiers) == DO_NOT_VISIT_SUBTREE) {
-                return DO_NOT_VISIT_SUBTREE;
+            for (final QualifiedName qualifiedNameToProcess : visitor.getQualifiedNamesToProcess()) {
+                if (maybeReplaceFqnWithSimpleName(qualifiedNameToProcess, localIdentifiers) == DO_NOT_VISIT_SUBTREE) {
+                    return DO_NOT_VISIT_SUBTREE;
+                }
             }
         }
 

--- a/plugin/src/main/java/org/autorefactor/refactoring/rules/ReplaceQualifiedNamesBySimpleNamesRefactoring.java
+++ b/plugin/src/main/java/org/autorefactor/refactoring/rules/ReplaceQualifiedNamesBySimpleNamesRefactoring.java
@@ -173,7 +173,7 @@ public class ReplaceQualifiedNamesBySimpleNamesRefactoring extends AbstractRefac
         @Override
         public String toString() {
             if (this.equals(CANNOT_REPLACE_SIMPLE_NAME)) {
-                return "CAN_NOT_REPLACE_SIMPLE_NAME";
+                return "CANNOT_REPLACE_SIMPLE_NAME";
             }
             return fullyQualifiedName + (fromImport ? " (imported)" : " (member)");
         }
@@ -635,7 +635,7 @@ public class ReplaceQualifiedNamesBySimpleNamesRefactoring extends AbstractRefac
         for (final SingleVariableDeclaration localParameter : ASTHelper.parameters(node)) {
             localIdentifiers.add(localParameter.getName().getIdentifier());
         }
-        localIdentifiers.addAll(ASTHelper.getLocalVariables(node.getBody(), true));
+        localIdentifiers.addAll(getLocalVariables(node.getBody(), true));
 
         return processNode(node.getBody(), localIdentifiers);
     }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/ReplaceQualifiedNamesBySimpleNamesSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/ReplaceQualifiedNamesBySimpleNamesSample.java
@@ -2,6 +2,7 @@
  * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
  *
  * Copyright (C) 2016 Jean-Noël Rouvignac - initial API and implementation
+ * Copyright (C) 2016 Fabrice Tiercelin - Handle local variable and outer classes
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -188,5 +189,34 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
 
     public void doNotConflictClassFieldAndLocalVariable(long classField) {
         ReplaceQualifiedNamesBySimpleNamesSample.classField = classField;
+    }
+
+    static String property = null;
+    static void setProperty(String property) {
+        ReplaceQualifiedNamesBySimpleNamesSample.property = property;
+    }
+
+    public void doNotConflictClassFieldAndOuterClassField(String text) {
+        Outer.outerProperty = text;
+        Outer.NestedOuter.nestedOuterProperty = text;
+    }
+
+}
+
+class Outer {
+
+    static java.lang.String outerProperty = null;
+
+    void foo() {
+        ReplaceQualifiedNamesBySimpleNamesSample.setProperty("hi");
+    }
+
+    static class NestedOuter {
+
+        static java.lang.String nestedOuterProperty = "bar";
+
+        void bar() {
+            ReplaceQualifiedNamesBySimpleNamesSample.setProperty("hi");
+        }
     }
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/ReplaceQualifiedNamesBySimpleNamesSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/ReplaceQualifiedNamesBySimpleNamesSample.java
@@ -40,6 +40,16 @@ import java.util.List;
 import java.util.Map;
 
 public class ReplaceQualifiedNamesBySimpleNamesSample {
+
+    private static long classField = 0l;
+
+    private java.lang.Long instanceField = java.lang.Long.MIN_VALUE;
+
+    static {
+        long classField = 0l;
+        ReplaceQualifiedNamesBySimpleNamesSample.classField = java.lang.Long.MAX_VALUE + classField;
+    }
+
     public java.util.List<String> removeQualifiedNameForImportNoWildcard(List<String> l) {
         return l;
     }
@@ -62,6 +72,10 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
 
     public void doNotRemoveQualifiedNameForGenericStaticMethodImport() {
         acceptListString(Collections.<String> emptyList());
+    }
+
+    public long removeQualifiedNameForParameterType(java.lang.Long i) {
+        return i;
     }
 
     private void acceptListString(List<String> l) {
@@ -166,5 +180,13 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
             return b().equals(other.b())
                 && i.equals(other.i);
         }
+    }
+
+    public void doNotConflictInstanceFieldAndLocalVariable(long instanceField) {
+        this.instanceField = instanceField;
+    }
+
+    public void doNotConflictClassFieldAndLocalVariable(long classField) {
+        ReplaceQualifiedNamesBySimpleNamesSample.classField = classField;
     }
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/ReplaceQualifiedNamesBySimpleNamesSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/ReplaceQualifiedNamesBySimpleNamesSample.java
@@ -51,6 +51,10 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
         ReplaceQualifiedNamesBySimpleNamesSample.classField = java.lang.Long.MAX_VALUE + classField;
     }
 
+    public ReplaceQualifiedNamesBySimpleNamesSample(java.lang.Long long1) {
+        java.lang.Long long2 = java.lang.Long.valueOf(long1 + 1);
+    }
+
     public java.util.List<String> removeQualifiedNameForImportNoWildcard(List<String> l) {
         return l;
     }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/ReplaceQualifiedNamesBySimpleNamesSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/ReplaceQualifiedNamesBySimpleNamesSample.java
@@ -40,6 +40,16 @@ import java.util.List;
 import java.util.Map;
 
 public class ReplaceQualifiedNamesBySimpleNamesSample {
+
+    private static long classField = 0l;
+
+    private Long instanceField = Long.MIN_VALUE;
+
+    static {
+        long classField = 0l;
+        ReplaceQualifiedNamesBySimpleNamesSample.classField = Long.MAX_VALUE + classField;
+    }
+
     public List<String> removeQualifiedNameForImportNoWildcard(List<String> l) {
         return l;
     }
@@ -62,6 +72,10 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
 
     public void doNotRemoveQualifiedNameForGenericStaticMethodImport() {
         acceptListString(Collections.<String> emptyList());
+    }
+
+    public long removeQualifiedNameForParameterType(Long i) {
+        return i;
     }
 
     private void acceptListString(List<String> l) {
@@ -166,5 +180,13 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
             return b().equals(other.b())
                 && i.equals(other.i);
         }
+    }
+
+    public void doNotConflictInstanceFieldAndLocalVariable(long instanceField) {
+        this.instanceField = instanceField;
+    }
+
+    public void doNotConflictClassFieldAndLocalVariable(long classField) {
+        ReplaceQualifiedNamesBySimpleNamesSample.classField = classField;
     }
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/ReplaceQualifiedNamesBySimpleNamesSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/ReplaceQualifiedNamesBySimpleNamesSample.java
@@ -2,6 +2,7 @@
  * AutoRefactor - Eclipse plugin to automatically refactor Java code bases.
  *
  * Copyright (C) 2016 Jean-Noël Rouvignac - initial API and implementation
+ * Copyright (C) 2016 Fabrice Tiercelin - Handle local variable and outer classes
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -188,5 +189,34 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
 
     public void doNotConflictClassFieldAndLocalVariable(long classField) {
         ReplaceQualifiedNamesBySimpleNamesSample.classField = classField;
+    }
+
+    static String property = null;
+    static void setProperty(String property) {
+        ReplaceQualifiedNamesBySimpleNamesSample.property = property;
+    }
+
+    public void doNotConflictClassFieldAndOuterClassField(String text) {
+        Outer.outerProperty = text;
+        Outer.NestedOuter.nestedOuterProperty = text;
+    }
+
+}
+
+class Outer {
+
+    static String outerProperty = null;
+
+    void foo() {
+        ReplaceQualifiedNamesBySimpleNamesSample.setProperty("hi");
+    }
+
+    static class NestedOuter {
+
+        static String nestedOuterProperty = "bar";
+
+        void bar() {
+            ReplaceQualifiedNamesBySimpleNamesSample.setProperty("hi");
+        }
     }
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/ReplaceQualifiedNamesBySimpleNamesSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/ReplaceQualifiedNamesBySimpleNamesSample.java
@@ -51,6 +51,10 @@ public class ReplaceQualifiedNamesBySimpleNamesSample {
         ReplaceQualifiedNamesBySimpleNamesSample.classField = Long.MAX_VALUE + classField;
     }
 
+    public ReplaceQualifiedNamesBySimpleNamesSample(Long long1) {
+        Long long2 = Long.valueOf(long1 + 1);
+    }
+
     public List<String> removeQualifiedNameForImportNoWildcard(List<String> l) {
         return l;
     }


### PR DESCRIPTION
This PR fixes the both cases of #222.

Unfortunately, there are still glitches. If the mother class of the refactored class has fields with identical names as fields from another class, the fields will be shadowed. We can't fix that because the information is in a different `.class`.