### PR TITLE
Update BREE of plugin.tests to Java 8

### DIFF
--- a/plugin.tests/META-INF/MANIFEST.MF
+++ b/plugin.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: AutoRefactor Tests
 Bundle-SymbolicName: org.autorefactor.plugin.tests;singleton:=true
 Bundle-Version: 1.3.0.qualifier
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.8.2",
  org.autorefactor.plugin,
  org.eclipse.core.jobs,

--- a/plugin.ui/src/main/java/org/autorefactor/AutoRefactorPlugin.java
+++ b/plugin.ui/src/main/java/org/autorefactor/AutoRefactorPlugin.java
@@ -25,6 +25,7 @@
  */
 package org.autorefactor;
 
+import java.util.ArrayList;
 import java.util.Vector;
 
 import org.autorefactor.environment.Environment;
@@ -162,7 +163,7 @@ public class AutoRefactorPlugin extends AbstractUIPlugin {
     }
 
     private static class JobManagerImpl implements JobManager {
-        private final Vector<Job> jobs= new Vector<>();
+        private final ArrayList<Job> jobs= new  ArrayList<>();
 
         /**
          * Register a job.


### PR DESCRIPTION
This is required to make Tycho build work again for me. plugin.tests uses already Java 8 and its BREE needs to adjusted