### PR TITLE
fix author name in feature description

### DIFF
--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -9,8 +9,7 @@
    </description>
 
    <copyright url="https://github.com/JnRouvignac/AutoRefactor/blob/master/COPYRIGHT.txt">
-      Copyright 2013-2014 Jean-No&amp;euml;l Rouvignac and the AutoRefactor
-project.
+      Copyright 2013-2014 Jean-No&#xeb;l Rouvignac and the AutoRefactor project.
    </copyright>
 
    <license url="https://github.com/JnRouvignac/AutoRefactor/blob/master/COPYRIGHT.txt">


### PR DESCRIPTION
The umlaut was encoded twice. Additionally the feature editor does not
like named HTML entities, therefore numeric encoding is the only variant
that doesn't cause issues.