### PR TITLE
Show search icon in refactorings filter

### DIFF
--- a/plugin.ui/src/main/java/org/autorefactor/ui/ChooseRefactoringWizardPage.java
+++ b/plugin.ui/src/main/java/org/autorefactor/ui/ChooseRefactoringWizardPage.java
@@ -171,7 +171,7 @@ public class ChooseRefactoringWizardPage extends WizardPage {
     }
 
     private void createFilterText(Composite parent) {
-        filterText= new Text(parent, BORDER | SWT.SINGLE);
+        filterText= new Text(parent, BORDER | SWT.SINGLE | SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
         filterText.setMessage("Type in to filter refactorings"); //$NON-NLS-1$
         filterText.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 


### PR DESCRIPTION
Show the search (and cancel) icon inside the text box for filtering
refactorings. On Windows this is only visible with the latest eclipse
2019-09.