### PR TITLE
Simplify key binding configuration

### DIFF
--- a/plugin.ui/plugin.xml
+++ b/plugin.ui/plugin.xml
@@ -102,16 +102,18 @@
 
     <extension point="org.eclipse.ui.commands">
         <command
-                id="org.autorefactor.automatic.refactoring"
-                defaultHandler="org.autorefactor.ui.AutoRefactorHandler"
-                name="AutoRefactor Clean Up">
+              categoryId="org.eclipse.jdt.ui.category.refactoring"
+              defaultHandler="org.autorefactor.ui.AutoRefactorHandler"
+              description="Execute all enabled AutoRefactor refactorings on selection"
+              id="org.autorefactor.automatic.refactoring"
+              name="AutoRefactor Clean Up">
         </command>
-    </extension>
-    <extension point="org.eclipse.ui.commands">
         <command
-                id="org.autorefactor.choose.refactorings"
-                defaultHandler="org.autorefactor.ui.ChooseRefactoringsWizardHandler"
-                name="Choose refactorings...">
+              categoryId="org.eclipse.jdt.ui.category.refactoring"
+              defaultHandler="org.autorefactor.ui.ChooseRefactoringsWizardHandler"
+              description="Choose AutoRefactor refactorings to execute on selection"
+              id="org.autorefactor.choose.refactorings"
+              name="Choose refactorings...">
         </command>
     </extension>
     


### PR DESCRIPTION
* Add a description to the commands (shown in preferences > keys and in
the Ctrl-3 quick assist dropdown)
* Add the Java refactorings category to the commands. That way the
commands are shown by default on the key bindings preference page
(otherwise only when selecting the checkbox to show uncategorized
commands).