### PR TITLE
Fix #394: check environment during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.4.0</tycho-version>
 	</properties>
 
 	<scm>
@@ -203,6 +203,31 @@ http://www.solutionsiq.com/developing-eclipse-plug-ins-program-to-publish/
 							<includes>**/META-INF/MANIFEST.MF,**/feature.xml,**/*.product,**/category.xml</includes>
 							<excludes>**/target/**</excludes>
 							<message>Changing the Eclipse files versions</message>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>(,3.6.1)</version>
+									<message>Maven 3.6.1 has a bug resolving P2 repositories.</message>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>[1.5.0,1.8.1)</version>
+									<message>Cannot build on JDK higher than 8 due to tests failing on more recent JDK.</message>
+								</requireJavaVersion>
+							</rules>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
* enforce JDK 5 to 8 (to avoid failing tests as reported by Lars)
* enforce Maven < 3.6.1 to avoid P2 repository resolution error
* upgrade Tycho build tooling to 1.4.0

On my machine I have 6 tests failing with or without this change.