### PR TITLE
Fix #419: Handle underscore in BigNumber refactoring

### DIFF
--- a/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/BigNumberCleanUp.java
+++ b/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/BigNumberCleanUp.java
@@ -118,7 +118,7 @@ public class BigNumberCleanUp extends AbstractCleanUpRule {
 
                 if (literalValue.contains(".") && literalValue.contains("_")) { //$NON-NLS-1$ //$NON-NLS-2$
                     // Only instantiation from double, not from integer
-                    ctx.getRefactorings().replace(arg0, getStringLiteral(literalValue.replace("_", "")));
+                    ctx.getRefactorings().replace(arg0, getStringLiteral(literalValue.replace("_", ""))); //$NON-NLS-1$ //$NON-NLS-2$
                     return false;
                 }
 

--- a/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/BigNumberCleanUp.java
+++ b/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/BigNumberCleanUp.java
@@ -85,7 +85,7 @@ public class BigNumberCleanUp extends AbstractCleanUpRule {
             final Expression arg0= ASTNodes.arguments(node).get(0);
 
             if (arg0 instanceof NumberLiteral && ASTNodes.hasType(typeBinding, BigDecimal.class.getCanonicalName())) {
-                final String token= ((NumberLiteral) arg0).getToken().replaceFirst("[lLfFdD]$", ""); //$NON-NLS-1$ //$NON-NLS-2$
+                final String token= ((NumberLiteral) arg0).getToken().replaceFirst("[lLfFdD]$", "").replace("_", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
                 if (token.contains(".")) { //$NON-NLS-1$
                     // Only instantiation from double, not from integer
@@ -115,6 +115,12 @@ public class BigNumberCleanUp extends AbstractCleanUpRule {
                 }
 
                 final String literalValue= ((StringLiteral) arg0).getLiteralValue().replaceFirst("[lLfFdD]$", ""); //$NON-NLS-1$ //$NON-NLS-2$
+
+                if (literalValue.contains(".") && literalValue.contains("_")) { //$NON-NLS-1$ //$NON-NLS-2$
+                    // Only instantiation from double, not from integer
+                    ctx.getRefactorings().replace(arg0, getStringLiteral(literalValue.replace("_", "")));
+                    return false;
+                }
 
                 if (literalValue.matches("0+")) { //$NON-NLS-1$
                     return replaceWithQualifiedName(node, typeBinding, "ZERO"); //$NON-NLS-1$

--- a/samples/src/test/java/org/autorefactor/jdt/internal/ui/fix/samples_in/BigNumberSample.java
+++ b/samples/src/test/java/org/autorefactor/jdt/internal/ui/fix/samples_in/BigNumberSample.java
@@ -141,4 +141,8 @@ public class BigNumberSample {
     public static BigDecimal doNotRefactorCorrectUseOfBigDecimalCtorWithStringArg() {
         return new BigDecimal("5.4");
     }
+
+    public static BigDecimal removeUnderscoreFromLiterals() {
+        return BigDecimal.valueOf(1_000.0);
+    }
 }

--- a/samples/src/test/java/org/autorefactor/jdt/internal/ui/fix/samples_out/BigNumberSample.java
+++ b/samples/src/test/java/org/autorefactor/jdt/internal/ui/fix/samples_out/BigNumberSample.java
@@ -142,4 +142,8 @@ public class BigNumberSample {
     public static BigDecimal doNotRefactorCorrectUseOfBigDecimalCtorWithStringArg() {
         return new BigDecimal("5.4");
     }
+
+    public static BigDecimal removeUnderscoreFromLiterals() {
+        return new BigDecimal("1000.0");
+    }
 }


### PR DESCRIPTION
Remove underscores from literals when converting from numeric literal
based constructor to String based constructor. Otherwise the String
based constructor throws NumberFormatExceptions.