### PR TITLE
Remove unnecessary local before return clean up

### DIFF
--- a/plugin/src/main/java/org/autorefactor/jdt/internal/corext/dom/ASTNodeFactory.java
+++ b/plugin/src/main/java/org/autorefactor/jdt/internal/corext/dom/ASTNodeFactory.java
@@ -167,7 +167,8 @@ public class ASTNodeFactory {
 	 * @param rightHandSide      the right hand side expression
 	 * @return a new Assignment
 	 */
-	public Assignment newAssignment(final Expression leftHandSide, final Assignment.Operator operator, final Expression rightHandSide) {
+	public Assignment newAssignment(final Expression leftHandSide, final Assignment.Operator operator,
+			final Expression rightHandSide) {
 		Assignment newAssignment= newAssignment();
 		newAssignment.setLeftHandSide(leftHandSide);
 		newAssignment.setOperator(operator);
@@ -329,7 +330,8 @@ public class ASTNodeFactory {
 	 * @param statements          the statements to add to the catch clause
 	 * @return a new catch clause
 	 */
-	public CatchClause newCatchClause(final String exceptionTypeName, final String caughtExceptionName, final Statement... statements) {
+	public CatchClause newCatchClause(final String exceptionTypeName, final String caughtExceptionName,
+			final Statement... statements) {
 		CatchClause cc= ast.newCatchClause();
 		SingleVariableDeclaration svd= ast.newSingleVariableDeclaration();
 		svd.setType(simpleType(exceptionTypeName));
@@ -405,8 +407,8 @@ public class ASTNodeFactory {
 			if (typeBinding.getTypeBounds().length > 1) {
 				throw new NotImplementedException(null,
 						"because it violates the javadoc of `ITypeBinding.getTypeBounds()`: " //$NON-NLS-1$
-						+ "\"Note that per construction, it can only contain one class or array type, " //$NON-NLS-1$
-						+ "at most, and then it is located in first position.\""); //$NON-NLS-1$
+								+ "\"Note that per construction, it can only contain one class or array type, " //$NON-NLS-1$
+								+ "at most, and then it is located in first position.\""); //$NON-NLS-1$
 			}
 
 			return toType(typeBinding.getWildcard(), typeNameDecider);
@@ -544,7 +546,8 @@ public class ASTNodeFactory {
 	 * @param initializer the variable initializer, can be null
 	 * @return a new variable declaration statement
 	 */
-	public VariableDeclarationStatement declareStatement(final Type type, final SimpleName varName, final Expression initializer) {
+	public VariableDeclarationStatement declareStatement(final Type type, final SimpleName varName,
+			final Expression initializer) {
 		VariableDeclarationFragment fragment= newVariableDeclarationFragment(varName, initializer);
 		return newVariableDeclarationStatement(type, fragment);
 	}
@@ -556,7 +559,8 @@ public class ASTNodeFactory {
 	 * @param fragment the fragment being declared
 	 * @return a new variable declaration statement
 	 */
-	public VariableDeclarationStatement newVariableDeclarationStatement(final Type type, final VariableDeclarationFragment fragment) {
+	public VariableDeclarationStatement newVariableDeclarationStatement(final Type type,
+			final VariableDeclarationFragment fragment) {
 		VariableDeclarationStatement variableDeclarationStatement= ast.newVariableDeclarationStatement(fragment);
 		variableDeclarationStatement.setType(type);
 		return variableDeclarationStatement;
@@ -570,7 +574,8 @@ public class ASTNodeFactory {
 	 * @param initializer the variable initializer, can be null
 	 * @return a new variable declaration expression
 	 */
-	public VariableDeclarationExpression newVariableDeclarationExpression(final Type type, final SimpleName varName, final Expression initializer) {
+	public VariableDeclarationExpression newVariableDeclarationExpression(final Type type, final SimpleName varName,
+			final Expression initializer) {
 		VariableDeclarationFragment fragment= newVariableDeclarationFragment(varName, initializer);
 		VariableDeclarationExpression variableDeclarationExpression= ast.newVariableDeclarationExpression(fragment);
 		variableDeclarationExpression.modifiers().add(final0());
@@ -585,7 +590,8 @@ public class ASTNodeFactory {
 	 * @param fragment the variable declaration fragment
 	 * @return a new variable declaration expression
 	 */
-	public VariableDeclarationExpression newVariableDeclarationExpression(final Type type, final VariableDeclarationFragment fragment) {
+	public VariableDeclarationExpression newVariableDeclarationExpression(final Type type,
+			final VariableDeclarationFragment fragment) {
 		VariableDeclarationExpression variableDeclarationExpression= ast.newVariableDeclarationExpression(fragment);
 		variableDeclarationExpression.setType(type);
 		return variableDeclarationExpression;
@@ -623,7 +629,8 @@ public class ASTNodeFactory {
 	 * @param initializer the variable initializer
 	 * @return a new variable declaration fragment
 	 */
-	public VariableDeclarationFragment newVariableDeclarationFragment(final SimpleName varName, final Expression initializer) {
+	public VariableDeclarationFragment newVariableDeclarationFragment(final SimpleName varName,
+			final Expression initializer) {
 		VariableDeclarationFragment fragment= ast.newVariableDeclarationFragment();
 		fragment.setName(varName);
 		fragment.setInitializer(initializer);
@@ -738,7 +745,8 @@ public class ASTNodeFactory {
 	 *                       false
 	 * @return a new conditional expression
 	 */
-	public ConditionalExpression newConditionalExpression(final Expression mainExpression, final Expression thenExpression,
+	public ConditionalExpression newConditionalExpression(final Expression mainExpression,
+			final Expression thenExpression,
 			final Expression elseExpression) {
 		ConditionalExpression ce= ast.newConditionalExpression();
 		ce.setExpression(mainExpression);
@@ -765,7 +773,8 @@ public class ASTNodeFactory {
 	 * @param extendedOperands the extended operands
 	 * @return a new infix expression
 	 */
-	public InfixExpression newInfixExpression(Expression leftOperand, InfixExpression.Operator operator, Expression rightOperand,
+	public InfixExpression newInfixExpression(Expression leftOperand, InfixExpression.Operator operator,
+			Expression rightOperand,
 			Expression... extendedOperands) {
 		InfixExpression newInfixExpression= newInfixExpression();
 		newInfixExpression.setLeftOperand(leftOperand);
@@ -782,7 +791,8 @@ public class ASTNodeFactory {
 	 * @param allOperands the operands
 	 * @return a new infix expression
 	 */
-	public InfixExpression newInfixExpression(final InfixExpression.Operator operator, final Collection<? extends Expression> allOperands) {
+	public InfixExpression newInfixExpression(final InfixExpression.Operator operator,
+			final Collection<? extends Expression> allOperands) {
 		if (allOperands.size() < 2) {
 			throw new IllegalArgumentException(null, "Not enough operands for an infix expression: " //$NON-NLS-1$
 					+ "needed at least 2, but got " + allOperands.size()); //$NON-NLS-1$
@@ -1020,7 +1030,8 @@ public class ASTNodeFactory {
 				Expression otherExpression= prefixExpression.getOperand();
 				PrefixExpression otherPrefixExpression= ASTNodes.as(otherExpression, PrefixExpression.class);
 
-				if (otherPrefixExpression != null && ASTNodes.hasOperator(otherPrefixExpression, PrefixExpression.Operator.NOT)) {
+				if (otherPrefixExpression != null
+						&& ASTNodes.hasOperator(otherPrefixExpression, PrefixExpression.Operator.NOT)) {
 					return negate(otherPrefixExpression.getOperand(), isMove);
 				}
 
@@ -1036,7 +1047,9 @@ public class ASTNodeFactory {
 		} else if (unparenthesedExpression instanceof ConditionalExpression) {
 			ConditionalExpression aConditionalExpression= (ConditionalExpression) unparenthesedExpression;
 
-			return newConditionalExpression(isMove ? createMoveTarget(aConditionalExpression.getExpression()) : createCopyTarget(aConditionalExpression.getExpression()),
+			return newConditionalExpression(
+					isMove ? createMoveTarget(aConditionalExpression.getExpression())
+							: createCopyTarget(aConditionalExpression.getExpression()),
 					negate(aConditionalExpression.getThenExpression(), isMove),
 					negate(aConditionalExpression.getElseExpression(), isMove));
 		} else {
@@ -1054,11 +1067,13 @@ public class ASTNodeFactory {
 		return not(createCopyTarget(unparenthesedExpression));
 	}
 
-	private Expression getNegatedOperation(final InfixExpression booleanOperation, final InfixExpression.Operator negatedOperator, final boolean isMove) {
+	private Expression getNegatedOperation(final InfixExpression booleanOperation,
+			final InfixExpression.Operator negatedOperator, final boolean isMove) {
 		List<Expression> allOperands= ASTNodes.allOperands(booleanOperation);
 		List<Expression> allTargetOperands;
 
-		if (ASTNodes.hasOperator(booleanOperation, InfixExpression.Operator.CONDITIONAL_AND, InfixExpression.Operator.CONDITIONAL_OR, InfixExpression.Operator.AND,
+		if (ASTNodes.hasOperator(booleanOperation, InfixExpression.Operator.CONDITIONAL_AND,
+				InfixExpression.Operator.CONDITIONAL_OR, InfixExpression.Operator.AND,
 				InfixExpression.Operator.OR)) {
 			allTargetOperands= new ArrayList<>(allOperands.size());
 
@@ -1068,7 +1083,8 @@ public class ASTNodeFactory {
 				if (negatedOperand != null) {
 					allTargetOperands.add(negatedOperand);
 				} else {
-					PrefixExpression prefixExpression= newPrefixExpression(PrefixExpression.Operator.NOT, isMove ? createMoveTarget(booleanOperand) : createCopyTarget(booleanOperand));
+					PrefixExpression prefixExpression= newPrefixExpression(PrefixExpression.Operator.NOT,
+							isMove ? createMoveTarget(booleanOperand) : createCopyTarget(booleanOperand));
 
 					allTargetOperands.add(prefixExpression);
 				}

--- a/plugin/src/main/java/org/autorefactor/jdt/internal/corext/dom/ASTNodeFactory.java
+++ b/plugin/src/main/java/org/autorefactor/jdt/internal/corext/dom/ASTNodeFactory.java
@@ -1036,10 +1036,9 @@ public class ASTNodeFactory {
 		} else if (unparenthesedExpression instanceof ConditionalExpression) {
 			ConditionalExpression aConditionalExpression= (ConditionalExpression) unparenthesedExpression;
 
-			ConditionalExpression newConditionalExpression= newConditionalExpression(isMove ? createMoveTarget(aConditionalExpression.getExpression()) : createCopyTarget(aConditionalExpression.getExpression()),
+			return newConditionalExpression(isMove ? createMoveTarget(aConditionalExpression.getExpression()) : createCopyTarget(aConditionalExpression.getExpression()),
 					negate(aConditionalExpression.getThenExpression(), isMove),
 					negate(aConditionalExpression.getElseExpression(), isMove));
-			return newConditionalExpression;
 		} else {
 			Boolean constant= ASTNodes.getBooleanLiteral(unparenthesedExpression);
 

--- a/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/DeclarationOutsideLoopRatherThanInsideCleanUp.java
+++ b/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/DeclarationOutsideLoopRatherThanInsideCleanUp.java
@@ -111,7 +111,8 @@ public class DeclarationOutsideLoopRatherThanInsideCleanUp extends AbstractClean
 				List<VariableDeclarationStatement> candidates= new ArrayList<>();
 
 				for (Statement declarationStatement : forStatements) {
-					VariableDeclarationStatement declaration= ASTNodes.as(declarationStatement, VariableDeclarationStatement.class);
+					VariableDeclarationStatement declaration= ASTNodes.as(declarationStatement,
+							VariableDeclarationStatement.class);
 					VariableDeclarationFragment fragment= ASTNodes.getUniqueFragment(declaration);
 
 					if (fragment != null
@@ -144,7 +145,8 @@ public class DeclarationOutsideLoopRatherThanInsideCleanUp extends AbstractClean
 		return result;
 	}
 
-	private boolean isEffectivelyFinalRequired(final VariableDeclarationStatement declaration, final VariableDeclarationFragment fragment) {
+	private boolean isEffectivelyFinalRequired(final VariableDeclarationStatement declaration,
+			final VariableDeclarationFragment fragment) {
 		if (Modifier.isFinal(declaration.getModifiers())) {
 			return true;
 		}
@@ -153,7 +155,8 @@ public class DeclarationOutsideLoopRatherThanInsideCleanUp extends AbstractClean
 		List<SimpleName> reads= visitor.getReads();
 
 		for (SimpleName read : reads) {
-			ASTNode ancestor= ASTNodes.getFirstAncestorOrNull(read, AnonymousClassDeclaration.class, LambdaExpression.class);
+			ASTNode ancestor= ASTNodes.getFirstAncestorOrNull(read, AnonymousClassDeclaration.class,
+					LambdaExpression.class);
 
 			if (ancestor != null && !ASTNodes.isParent(fragment, ancestor)) {
 				return true;
@@ -176,7 +179,8 @@ public class DeclarationOutsideLoopRatherThanInsideCleanUp extends AbstractClean
 	private void moveDeclaration(final Statement statement, final VariableDeclarationStatement varToMove) {
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
 		ASTNodeFactory ast= cuRewrite.getASTBuilder();
-		TextEditGroup group= new TextEditGroup(MultiFixMessages.DeclarationOutsideLoopRatherThanInsideCleanUp_description);
+		TextEditGroup group= new TextEditGroup(
+				MultiFixMessages.DeclarationOutsideLoopRatherThanInsideCleanUp_description);
 
 		VariableDeclarationFragment fragment= (VariableDeclarationFragment) varToMove.fragments().get(0);
 
@@ -187,7 +191,8 @@ public class DeclarationOutsideLoopRatherThanInsideCleanUp extends AbstractClean
 			List<Dimension> extraDimensions= fragment.extraDimensions();
 			List<Dimension> newExtraDimensions= newFragment.extraDimensions();
 			newExtraDimensions.addAll(ASTNodes.createMoveTarget(rewrite, extraDimensions));
-			VariableDeclarationStatement newDeclareStatement= ast.newVariableDeclarationStatement(copyOfType, newFragment);
+			VariableDeclarationStatement newDeclareStatement= ast.newVariableDeclarationStatement(copyOfType,
+					newFragment);
 			List<IExtendedModifier> modifiers= varToMove.modifiers();
 			List<IExtendedModifier> newModifiers= newDeclareStatement.modifiers();
 
@@ -201,7 +206,9 @@ public class DeclarationOutsideLoopRatherThanInsideCleanUp extends AbstractClean
 
 			rewrite.insertBefore(newDeclareStatement, statement, group);
 			ASTNodes.replaceButKeepComment(rewrite, varToMove,
-					ast.newExpressionStatement(ast.newAssignment(ast.createCopyTarget(name), Assignment.Operator.ASSIGN, ASTNodes.createMoveTarget(rewrite, fragment.getInitializer()))), group);
+					ast.newExpressionStatement(ast.newAssignment(ast.createCopyTarget(name), Assignment.Operator.ASSIGN,
+							ASTNodes.createMoveTarget(rewrite, fragment.getInitializer()))),
+					group);
 		} else {
 			rewrite.insertBefore(ASTNodes.createMoveTarget(rewrite, varToMove), statement, group);
 			rewrite.remove(varToMove, group);

--- a/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/OneTryRatherThanTwoCleanUp.java
+++ b/plugin/src/main/java/org/autorefactor/jdt/internal/ui/fix/OneTryRatherThanTwoCleanUp.java
@@ -83,7 +83,9 @@ public class OneTryRatherThanTwoCleanUp extends AbstractCleanUpRule {
 		ASTNodeFactory ast= cuRewrite.getASTBuilder();
 		TextEditGroup group= new TextEditGroup(MultiFixMessages.OneTryRatherThanTwoCleanUp_description);
 
-		rewrite.insertLast(visited, TryStatement.RESOURCES_PROPERTY, ast.copyRange((List<VariableDeclarationExpression>) innerTryStatement.resources()), group);
-		ASTNodes.replaceButKeepComment(rewrite, visited.getBody(), ASTNodes.createMoveTarget(rewrite, innerTryStatement.getBody()), group);
+		rewrite.insertLast(visited, TryStatement.RESOURCES_PROPERTY,
+				ast.copyRange((List<VariableDeclarationExpression>) innerTryStatement.resources()), group);
+		ASTNodes.replaceButKeepComment(rewrite, visited.getBody(),
+				ASTNodes.createMoveTarget(rewrite, innerTryStatement.getBody()), group);
 	}
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/DeclarationOutsideLoopRatherThanInsideSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/DeclarationOutsideLoopRatherThanInsideSample.java
@@ -29,273 +29,273 @@ import java.util.List;
 import java.util.function.Predicate;
 
 public class DeclarationOutsideLoopRatherThanInsideSample {
-    public String moveObjectDecl(int count) {
-        StringBuilder concat = new StringBuilder();
+	public String moveObjectDecl(int count) {
+		StringBuilder concat= new StringBuilder();
 
-        for (int i = 0; i < count; i++) {
-            // Keep this comment
-            String newNumber = String.valueOf(i);
-            concat.append(newNumber);
-            concat.append(";");
-        }
+		for (int i= 0; i < count; i++) {
+			// Keep this comment
+			String newNumber= String.valueOf(i);
+			concat.append(newNumber);
+			concat.append(";");
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String moveArrayDecl(int count) {
-        StringBuilder concat = new StringBuilder();
+	public String moveArrayDecl(int count) {
+		StringBuilder concat= new StringBuilder();
 
-        for (int i = 0; i < count; i++) {
-            // Keep this comment
-            String newNumber[] = new String[]{String.valueOf(i)};
-            concat.append(newNumber);
-            concat.append(";");
-        }
+		for (int i= 0; i < count; i++) {
+			// Keep this comment
+			String newNumber[]= new String[] { String.valueOf(i) };
+			concat.append(newNumber);
+			concat.append(";");
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String moveObjectDeclFromLoops(int count) {
-        StringBuilder concat = new StringBuilder();
+	public String moveObjectDeclFromLoops(int count) {
+		StringBuilder concat= new StringBuilder();
 
-        for (int i = 0; i < count; i++) {
-            // Keep this comment
-            String newNumber = String.valueOf(i);
-            concat.append(newNumber);
-            concat.append(";");
+		for (int i= 0; i < count; i++) {
+			// Keep this comment
+			String newNumber= String.valueOf(i);
+			concat.append(newNumber);
+			concat.append(";");
 
-            for (int j = 0; j < count; j++) {
-                // Keep this comment
-                String anotherNewNumber = String.valueOf(j);
-                concat.append(anotherNewNumber);
-                concat.append(";");
-            }
-        }
+			for (int j= 0; j < count; j++) {
+				// Keep this comment
+				String anotherNewNumber= String.valueOf(j);
+				concat.append(anotherNewNumber);
+				concat.append(";");
+			}
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public int moveFromEnhancedLoop(List<String> myList) {
-        int total = 0;
+	public int moveFromEnhancedLoop(List<String> myList) {
+		int total= 0;
 
-        for (String number : myList) {
-            // Keep this comment
-            int newNumber = Integer.parseInt(number);
-            total += newNumber;
-        }
+		for (String number : myList) {
+			// Keep this comment
+			int newNumber= Integer.parseInt(number);
+			total+= newNumber;
+		}
 
-        return total;
-    }
+		return total;
+	}
 
-    public int moveFromWhile(int max) {
-        int result = 1;
+	public int moveFromWhile(int max) {
+		int result= 1;
 
-        while (result < max) {
-            // Keep this comment
-            int newNumber = result * result;
-            result += newNumber;
-        }
+		while (result < max) {
+			// Keep this comment
+			int newNumber= result * result;
+			result+= newNumber;
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    public int moveFromDoWhile(int max) {
-        int result = 1;
+	public int moveFromDoWhile(int max) {
+		int result= 1;
 
-        do {
-            // Keep this comment
-            int newNumber = result * result;
-            result += newNumber;
-        } while (result < max);
+		do {
+			// Keep this comment
+			int newNumber= result * result;
+			result+= newNumber;
+		} while (result < max);
 
-        return result;
-    }
+		return result;
+	}
 
-    public int moveComplexType(int max) {
-        int result = 1;
+	public int moveComplexType(int max) {
+		int result= 1;
 
-        do {
-            // Keep this comment
-            Class<?>[] complexObject = new Class<?>[0];
-            result += complexObject.length + 1;
-        } while (result < max);
+		do {
+			// Keep this comment
+			Class<?>[] complexObject= new Class<?>[0];
+			result+= complexObject.length + 1;
+		} while (result < max);
 
-        return result;
-    }
+		return result;
+	}
 
-    public int moveDeclWithoutInit(List<String> myList) {
-        int total = 0;
+	public int moveDeclWithoutInit(List<String> myList) {
+		int total= 0;
 
-        for (String number : myList) {
-            // Keep this comment
-            int newNumber;
-            newNumber = Integer.parseInt(number);
-            total += newNumber;
-        }
+		for (String number : myList) {
+			// Keep this comment
+			int newNumber;
+			newNumber= Integer.parseInt(number);
+			total+= newNumber;
+		}
 
-        return total;
-    }
+		return total;
+	}
 
-    public int movePrimitiveTypeDecl(List<String> myList) {
-        int total = 0;
+	public int movePrimitiveTypeDecl(List<String> myList) {
+		int total= 0;
 
-        for (String number : myList) {
-            // Keep this comment
-            int newNumber = Integer.parseInt(number);
-            total += newNumber;
-        }
+		for (String number : myList) {
+			// Keep this comment
+			int newNumber= Integer.parseInt(number);
+			total+= newNumber;
+		}
 
-        return total;
-    }
+		return total;
+	}
 
-    public String moveObjectDecls(List<Integer> myList1, List<Integer> myList2) {
-        StringBuilder concat = new StringBuilder();
+	public String moveObjectDecls(List<Integer> myList1, List<Integer> myList2) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList1) {
-            // Keep this comment
-            String newNumber = String.valueOf(number);
-            concat.append(newNumber);
-        }
+		for (Integer number : myList1) {
+			// Keep this comment
+			String newNumber= String.valueOf(number);
+			concat.append(newNumber);
+		}
 
-        for (Integer number : myList2) {
-            // Keep this comment
-            String anotherNumber = String.valueOf(number);
-            concat.append(anotherNumber);
-        }
+		for (Integer number : myList2) {
+			// Keep this comment
+			String anotherNumber= String.valueOf(number);
+			concat.append(anotherNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String moveWhenNoConflictsBefore(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String moveWhenNoConflictsBefore(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        {
-            String theNumber = "10 and ";
-            System.out.println(theNumber);
-        }
+		{
+			String theNumber= "10 and ";
+			System.out.println(theNumber);
+		}
 
-        for (Integer number : myList) {
-            // Keep this comment
-            String theNumber = String.valueOf(number);
-            concat.append(theNumber);
-        }
+		for (Integer number : myList) {
+			// Keep this comment
+			String theNumber= String.valueOf(number);
+			concat.append(theNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveFinalDecl(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveFinalDecl(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            final String newNumber = String.valueOf(number);
-            concat.append(newNumber);
-        }
+		for (Integer number : myList) {
+			final String newNumber= String.valueOf(number);
+			concat.append(newNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public void doNotMoveEffectivelyFinalDeclaration(List<Integer> myList, List<String> texts) {
-        for (Integer number : myList) {
-            String newNumber = String.valueOf(number);
-            texts.removeIf(e -> newNumber.equals(e + "0"));
-        }
-    }
+	public void doNotMoveEffectivelyFinalDeclaration(List<Integer> myList, List<String> texts) {
+		for (Integer number : myList) {
+			String newNumber= String.valueOf(number);
+			texts.removeIf(e -> newNumber.equals(e + "0"));
+		}
+	}
 
-    public void doNotMoveEffectivelyFinalDeclarationInAnonymousClass(List<Integer> myList, List<String> texts) {
-        for (Integer number : myList) {
-            String newNumber = String.valueOf(number);
-            final Predicate<? super String> filter = new Predicate<String>() {
+	public void doNotMoveEffectivelyFinalDeclarationInAnonymousClass(List<Integer> myList, List<String> texts) {
+		for (Integer number : myList) {
+			String newNumber= String.valueOf(number);
+			final Predicate<? super String> filter= new Predicate<String>() {
 
-                @Override
-                public boolean test(String e) {
-                    return newNumber.equals(e + "0");
-                }
-            };
-            texts.removeIf(filter);
-        }
-    }
+				@Override
+				public boolean test(String e) {
+					return newNumber.equals(e + "0");
+				}
+			};
+			texts.removeIf(filter);
+		}
+	}
 
-    public String doNotMoveMultiFragments(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveMultiFragments(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String newNumber, sameNumber = String.valueOf(number);
-            newNumber = "0";
-            concat.append(newNumber);
-            concat.append("<");
-            concat.append(sameNumber);
-        }
+		for (Integer number : myList) {
+			String newNumber, sameNumber= String.valueOf(number);
+			newNumber= "0";
+			concat.append(newNumber);
+			concat.append("<");
+			concat.append(sameNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveWhenConflicts(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveWhenConflicts(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String myNumber = String.valueOf(number);
-            concat.append(myNumber);
-        }
+		for (Integer number : myList) {
+			String myNumber= String.valueOf(number);
+			concat.append(myNumber);
+		}
 
-        String myNumber = " and 10";
+		String myNumber= " and 10";
 
-        return concat.toString() + myNumber;
-    }
+		return concat.toString() + myNumber;
+	}
 
-    public String doNotMoveWhenConflictsInLoopParameter(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveWhenConflictsInLoopParameter(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String myNumber = String.valueOf(number);
-            concat.append(myNumber);
-        }
+		for (Integer number : myList) {
+			String myNumber= String.valueOf(number);
+			concat.append(myNumber);
+		}
 
-        for (Integer myNumber : myList) {
-            concat.append(myNumber);
-        }
+		for (Integer myNumber : myList) {
+			concat.append(myNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveWhenConflictsAfter(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveWhenConflictsAfter(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String oneNumber = String.valueOf(number);
-            concat.append(oneNumber);
-        }
+		for (Integer number : myList) {
+			String oneNumber= String.valueOf(number);
+			concat.append(oneNumber);
+		}
 
-        {
-            String oneNumber = " and 10";
-            System.out.println(oneNumber);
-        }
+		{
+			String oneNumber= " and 10";
+			System.out.println(oneNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveDeclFromOtherScope(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveDeclFromOtherScope(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            if (number > 0) {
-                String aNumber = String.valueOf(number);
-                concat.append(aNumber);
-            }
-        }
+		for (Integer number : myList) {
+			if (number > 0) {
+				String aNumber= String.valueOf(number);
+				concat.append(aNumber);
+			}
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveAnnotatedDecl(List<Object> texts) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveAnnotatedDecl(List<Object> texts) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Object object : texts) {
-            @SuppressWarnings("unchecked")
-            List<String> text = (List<String>) object;
-            concat.append(text);
-            concat.append(";");
-        }
+		for (Object object : texts) {
+			@SuppressWarnings("unchecked")
+			List<String> text= (List<String>) object;
+			concat.append(text);
+			concat.append(";");
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/OneTryRatherThanTwoSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_in/OneTryRatherThanTwoSample.java
@@ -28,51 +28,51 @@ package org.autorefactor.refactoring.rules.samples_in;
 import java.io.FileInputStream;
 
 public class OneTryRatherThanTwoSample {
-    public void removeInnerTry() throws Exception {
-        // Keep this comment
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
+	public void removeInnerTry() throws Exception {
+		// Keep this comment
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
 
-                System.out.println("Another statement");
-            }
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+				System.out.println("Another statement");
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-    public void doNotRemoveInnerTryWithFinally() throws Exception {
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
-            } finally {
-                System.out.println("Do not lose me!");
-            }
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+	public void doNotRemoveInnerTryWithFinally() throws Exception {
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
+			} finally {
+				System.out.println("Do not lose me!");
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-    public void doNotRemoveInnerTryWithCatchClause() throws Exception {
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+	public void doNotRemoveInnerTryWithCatchClause() throws Exception {
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-    public void doNotRemoveInnerTryWithOtherStatements() throws Exception {
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
-            }
-            System.out.println("Do not lose me!");
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+	public void doNotRemoveInnerTryWithOtherStatements() throws Exception {
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
+			}
+			System.out.println("Do not lose me!");
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/DeclarationOutsideLoopRatherThanInsideSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/DeclarationOutsideLoopRatherThanInsideSample.java
@@ -29,285 +29,285 @@ import java.util.List;
 import java.util.function.Predicate;
 
 public class DeclarationOutsideLoopRatherThanInsideSample {
-    public String moveObjectDecl(int count) {
-        StringBuilder concat = new StringBuilder();
+	public String moveObjectDecl(int count) {
+		StringBuilder concat= new StringBuilder();
 
-        String newNumber;
-        for (int i = 0; i < count; i++) {
-            // Keep this comment
-            newNumber = String.valueOf(i);
-            concat.append(newNumber);
-            concat.append(";");
-        }
+		String newNumber;
+		for (int i= 0; i < count; i++) {
+			// Keep this comment
+			newNumber= String.valueOf(i);
+			concat.append(newNumber);
+			concat.append(";");
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String moveArrayDecl(int count) {
-        StringBuilder concat = new StringBuilder();
+	public String moveArrayDecl(int count) {
+		StringBuilder concat= new StringBuilder();
 
-        String newNumber[];
-        for (int i = 0; i < count; i++) {
-            // Keep this comment
-            newNumber = new String[]{String.valueOf(i)};
-            concat.append(newNumber);
-            concat.append(";");
-        }
+		String newNumber[];
+		for (int i= 0; i < count; i++) {
+			// Keep this comment
+			newNumber= new String[] { String.valueOf(i) };
+			concat.append(newNumber);
+			concat.append(";");
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String moveObjectDeclFromLoops(int count) {
-        StringBuilder concat = new StringBuilder();
+	public String moveObjectDeclFromLoops(int count) {
+		StringBuilder concat= new StringBuilder();
 
-        String newNumber;
-        String anotherNewNumber;
-        for (int i = 0; i < count; i++) {
-            // Keep this comment
-            newNumber = String.valueOf(i);
-            concat.append(newNumber);
-            concat.append(";");
+		String newNumber;
+		String anotherNewNumber;
+		for (int i= 0; i < count; i++) {
+			// Keep this comment
+			newNumber= String.valueOf(i);
+			concat.append(newNumber);
+			concat.append(";");
 
-            for (int j = 0; j < count; j++) {
-                // Keep this comment
-                anotherNewNumber = String.valueOf(j);
-                concat.append(anotherNewNumber);
-                concat.append(";");
-            }
-        }
+			for (int j= 0; j < count; j++) {
+				// Keep this comment
+				anotherNewNumber= String.valueOf(j);
+				concat.append(anotherNewNumber);
+				concat.append(";");
+			}
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public int moveFromEnhancedLoop(List<String> myList) {
-        int total = 0;
+	public int moveFromEnhancedLoop(List<String> myList) {
+		int total= 0;
 
-        int newNumber;
-        for (String number : myList) {
-            // Keep this comment
-            newNumber = Integer.parseInt(number);
-            total += newNumber;
-        }
+		int newNumber;
+		for (String number : myList) {
+			// Keep this comment
+			newNumber= Integer.parseInt(number);
+			total+= newNumber;
+		}
 
-        return total;
-    }
+		return total;
+	}
 
-    public int moveFromWhile(int max) {
-        int result = 1;
+	public int moveFromWhile(int max) {
+		int result= 1;
 
-        int newNumber;
-        while (result < max) {
-            // Keep this comment
-            newNumber = result * result;
-            result += newNumber;
-        }
+		int newNumber;
+		while (result < max) {
+			// Keep this comment
+			newNumber= result * result;
+			result+= newNumber;
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    public int moveFromDoWhile(int max) {
-        int result = 1;
+	public int moveFromDoWhile(int max) {
+		int result= 1;
 
-        int newNumber;
-        do {
-            // Keep this comment
-            newNumber = result * result;
-            result += newNumber;
-        } while (result < max);
+		int newNumber;
+		do {
+			// Keep this comment
+			newNumber= result * result;
+			result+= newNumber;
+		} while (result < max);
 
-        return result;
-    }
+		return result;
+	}
 
-    public int moveComplexType(int max) {
-        int result = 1;
+	public int moveComplexType(int max) {
+		int result= 1;
 
-        Class<?>[] complexObject;
-        do {
-            // Keep this comment
-            complexObject = new Class<?>[0];
-            result += complexObject.length + 1;
-        } while (result < max);
+		Class<?>[] complexObject;
+		do {
+			// Keep this comment
+			complexObject= new Class<?>[0];
+			result+= complexObject.length + 1;
+		} while (result < max);
 
-        return result;
-    }
+		return result;
+	}
 
-    public int moveDeclWithoutInit(List<String> myList) {
-        int total = 0;
+	public int moveDeclWithoutInit(List<String> myList) {
+		int total= 0;
 
-        // Keep this comment
-        int newNumber;
-        for (String number : myList) {
-            newNumber = Integer.parseInt(number);
-            total += newNumber;
-        }
+		// Keep this comment
+		int newNumber;
+		for (String number : myList) {
+			newNumber= Integer.parseInt(number);
+			total+= newNumber;
+		}
 
-        return total;
-    }
+		return total;
+	}
 
-    public int movePrimitiveTypeDecl(List<String> myList) {
-        int total = 0;
+	public int movePrimitiveTypeDecl(List<String> myList) {
+		int total= 0;
 
-        int newNumber;
-        for (String number : myList) {
-            // Keep this comment
-            newNumber = Integer.parseInt(number);
-            total += newNumber;
-        }
+		int newNumber;
+		for (String number : myList) {
+			// Keep this comment
+			newNumber= Integer.parseInt(number);
+			total+= newNumber;
+		}
 
-        return total;
-    }
+		return total;
+	}
 
-    public String moveObjectDecls(List<Integer> myList1, List<Integer> myList2) {
-        StringBuilder concat = new StringBuilder();
+	public String moveObjectDecls(List<Integer> myList1, List<Integer> myList2) {
+		StringBuilder concat= new StringBuilder();
 
-        String newNumber;
-        for (Integer number : myList1) {
-            // Keep this comment
-            newNumber = String.valueOf(number);
-            concat.append(newNumber);
-        }
+		String newNumber;
+		for (Integer number : myList1) {
+			// Keep this comment
+			newNumber= String.valueOf(number);
+			concat.append(newNumber);
+		}
 
-        String anotherNumber;
-        for (Integer number : myList2) {
-            // Keep this comment
-            anotherNumber = String.valueOf(number);
-            concat.append(anotherNumber);
-        }
+		String anotherNumber;
+		for (Integer number : myList2) {
+			// Keep this comment
+			anotherNumber= String.valueOf(number);
+			concat.append(anotherNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String moveWhenNoConflictsBefore(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String moveWhenNoConflictsBefore(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        {
-            String theNumber = "10 and ";
-            System.out.println(theNumber);
-        }
+		{
+			String theNumber= "10 and ";
+			System.out.println(theNumber);
+		}
 
-        String theNumber;
-        for (Integer number : myList) {
-            // Keep this comment
-            theNumber = String.valueOf(number);
-            concat.append(theNumber);
-        }
+		String theNumber;
+		for (Integer number : myList) {
+			// Keep this comment
+			theNumber= String.valueOf(number);
+			concat.append(theNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveFinalDecl(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveFinalDecl(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            final String newNumber = String.valueOf(number);
-            concat.append(newNumber);
-        }
+		for (Integer number : myList) {
+			final String newNumber= String.valueOf(number);
+			concat.append(newNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public void doNotMoveEffectivelyFinalDeclaration(List<Integer> myList, List<String> texts) {
-        for (Integer number : myList) {
-            String newNumber = String.valueOf(number);
-            texts.removeIf(e -> newNumber.equals(e + "0"));
-        }
-    }
+	public void doNotMoveEffectivelyFinalDeclaration(List<Integer> myList, List<String> texts) {
+		for (Integer number : myList) {
+			String newNumber= String.valueOf(number);
+			texts.removeIf(e -> newNumber.equals(e + "0"));
+		}
+	}
 
-    public void doNotMoveEffectivelyFinalDeclarationInAnonymousClass(List<Integer> myList, List<String> texts) {
-        for (Integer number : myList) {
-            String newNumber = String.valueOf(number);
-            final Predicate<? super String> filter = new Predicate<String>() {
+	public void doNotMoveEffectivelyFinalDeclarationInAnonymousClass(List<Integer> myList, List<String> texts) {
+		for (Integer number : myList) {
+			String newNumber= String.valueOf(number);
+			final Predicate<? super String> filter= new Predicate<String>() {
 
-                @Override
-                public boolean test(String e) {
-                    return newNumber.equals(e + "0");
-                }
-            };
-            texts.removeIf(filter);
-        }
-    }
+				@Override
+				public boolean test(String e) {
+					return newNumber.equals(e + "0");
+				}
+			};
+			texts.removeIf(filter);
+		}
+	}
 
-    public String doNotMoveMultiFragments(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveMultiFragments(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String newNumber, sameNumber = String.valueOf(number);
-            newNumber = "0";
-            concat.append(newNumber);
-            concat.append("<");
-            concat.append(sameNumber);
-        }
+		for (Integer number : myList) {
+			String newNumber, sameNumber= String.valueOf(number);
+			newNumber= "0";
+			concat.append(newNumber);
+			concat.append("<");
+			concat.append(sameNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveWhenConflicts(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveWhenConflicts(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String myNumber = String.valueOf(number);
-            concat.append(myNumber);
-        }
+		for (Integer number : myList) {
+			String myNumber= String.valueOf(number);
+			concat.append(myNumber);
+		}
 
-        String myNumber = " and 10";
+		String myNumber= " and 10";
 
-        return concat.toString() + myNumber;
-    }
+		return concat.toString() + myNumber;
+	}
 
-    public String doNotMoveWhenConflictsInLoopParameter(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveWhenConflictsInLoopParameter(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String myNumber = String.valueOf(number);
-            concat.append(myNumber);
-        }
+		for (Integer number : myList) {
+			String myNumber= String.valueOf(number);
+			concat.append(myNumber);
+		}
 
-        for (Integer myNumber : myList) {
-            concat.append(myNumber);
-        }
+		for (Integer myNumber : myList) {
+			concat.append(myNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveWhenConflictsAfter(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveWhenConflictsAfter(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            String oneNumber = String.valueOf(number);
-            concat.append(oneNumber);
-        }
+		for (Integer number : myList) {
+			String oneNumber= String.valueOf(number);
+			concat.append(oneNumber);
+		}
 
-        {
-            String oneNumber = " and 10";
-            System.out.println(oneNumber);
-        }
+		{
+			String oneNumber= " and 10";
+			System.out.println(oneNumber);
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveDeclFromOtherScope(List<Integer> myList) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveDeclFromOtherScope(List<Integer> myList) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Integer number : myList) {
-            if (number > 0) {
-                String aNumber = String.valueOf(number);
-                concat.append(aNumber);
-            }
-        }
+		for (Integer number : myList) {
+			if (number > 0) {
+				String aNumber= String.valueOf(number);
+				concat.append(aNumber);
+			}
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 
-    public String doNotMoveAnnotatedDecl(List<Object> texts) {
-        StringBuilder concat = new StringBuilder();
+	public String doNotMoveAnnotatedDecl(List<Object> texts) {
+		StringBuilder concat= new StringBuilder();
 
-        for (Object object : texts) {
-            @SuppressWarnings("unchecked")
-            List<String> text = (List<String>) object;
-            concat.append(text);
-            concat.append(";");
-        }
+		for (Object object : texts) {
+			@SuppressWarnings("unchecked")
+			List<String> text= (List<String>) object;
+			concat.append(text);
+			concat.append(";");
+		}
 
-        return concat.toString();
-    }
+		return concat.toString();
+	}
 }

--- a/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/OneTryRatherThanTwoSample.java
+++ b/samples/src/test/java/org/autorefactor/refactoring/rules/samples_out/OneTryRatherThanTwoSample.java
@@ -28,49 +28,49 @@ package org.autorefactor.refactoring.rules.samples_out;
 import java.io.FileInputStream;
 
 public class OneTryRatherThanTwoSample {
-    public void removeInnerTry() throws Exception {
-        // Keep this comment
-        try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-            System.out.println(inputStream.read());
+	public void removeInnerTry() throws Exception {
+		// Keep this comment
+		try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+			System.out.println(inputStream.read());
 
-            System.out.println("Another statement");
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+			System.out.println("Another statement");
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-    public void doNotRemoveInnerTryWithFinally() throws Exception {
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
-            } finally {
-                System.out.println("Do not lose me!");
-            }
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+	public void doNotRemoveInnerTryWithFinally() throws Exception {
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
+			} finally {
+				System.out.println("Do not lose me!");
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-    public void doNotRemoveInnerTryWithCatchClause() throws Exception {
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+	public void doNotRemoveInnerTryWithCatchClause() throws Exception {
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 
-    public void doNotRemoveInnerTryWithOtherStatements() throws Exception {
-        try {
-            try (final FileInputStream inputStream = new FileInputStream("out.txt")) {
-                System.out.println(inputStream.read());
-            }
-            System.out.println("Do not lose me!");
-        } catch (Exception e) {
-            throw e;
-        }
-    }
+	public void doNotRemoveInnerTryWithOtherStatements() throws Exception {
+		try {
+			try (final FileInputStream inputStream= new FileInputStream("out.txt")) {
+				System.out.println(inputStream.read());
+			}
+			System.out.println("Do not lose me!");
+		} catch (Exception e) {
+			throw e;
+		}
+	}
 }


### PR DESCRIPTION
@Fabrice-TIERCELIN If something does not cleanly apply because of parallel changes please request a re-base/re-creation freely via comment as you did with lambda cleanup. 

I also suggest that you execute the formatter after doing changes.
This way the formatted lines will be attributed to you and checkstyle is automatically happy.

Note that formatter will only format changes after commit d137806a as configured in pom.xml.

```
$ grep formatter pom.xml 
			<!-- formatter - https://github.com/diffplug/spotless/tree/main/plugin-maven -->
			<!-- run formatter with: mvn -Dtycho.mode=maven spotless:apply -->

```

Please note that the formatter config in pom.xml is set to:

``` 
                                               <lineEndings>WINDOWS</lineEndings>
```

because most (but not all of) the AutoRefactor source code has windows line endings.

You may consider removing that line and executing the formatter after that to switch to
the recommended git attribute based line endings.
