### PR TITLE
update formatter configuration for samples

### DIFF
--- a/samples/autorefactor-eclipse-format-samples.xml
+++ b/samples/autorefactor-eclipse-format-samples.xml
@@ -381,7 +381,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -136,8 +136,6 @@
         <artifactId>spotless-maven-plugin</artifactId>
         <version>2.7.0</version>
         <configuration>
-          <!-- optional: limit format enforcement to just the files changed by this git ref -->
-          <ratchetFrom>d137806a55d49614ec59828984e4b0e57001c058</ratchetFrom>
           <java>
             <removeUnusedImports />
             <lineEndings>WINDOWS</lineEndings>


### PR DESCRIPTION
The samples configuration is different to project configuration
only by having a space before equals operator and using spaces instead
of tabs.

```
AutoRefactor$ diff -u autorefactor-eclipse-format.xml samples/autorefactor-eclipse-format-samples.xml 
--- autorefactor-eclipse-format.xml	2021-02-28 14:57:36.627450232 +0100
+++ samples/autorefactor-eclipse-format-samples.xml	2021-03-01 18:43:51.602110391 +0100
@@ -147,7 +147,7 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="49"/>
         <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
@@ -381,7 +381,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
```

Sorry for killing the samples formatting in-between.
I didn't noticed the intended difference in formatting.
Diff after formatting appllied is now much shorter.
